### PR TITLE
Fix Visuals keyframes and shape masks

### DIFF
--- a/e2e/visual-add-all-keyframes.spec.js
+++ b/e2e/visual-add-all-keyframes.spec.js
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+
+const visualFile = process.env.E2E_VISUAL_FILE;
+test.use({ channel: "chrome" });
+test.skip(!visualFile, "Set E2E_VISUAL_FILE to an image or video file");
+
+test("Add all keyframes animates a real uploaded visual clip", async ({ page }) => {
+  await page.goto("/");
+  const languageDialog = page.getByRole("dialog");
+  if (await languageDialog.isVisible()) {
+    await languageDialog.getByRole("button", { name: /中文.*简体中文/ }).click();
+    await expect(languageDialog).toBeHidden();
+  }
+  await page.locator('input[type="file"][multiple]').setInputFiles(visualFile);
+
+  const asset = page.getByRole("button", { name: new RegExp(visualFile.split("/").at(-1).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")) });
+  await expect(asset).toContainText("1280 x 720");
+  await asset.dblclick();
+
+  await expect(page.locator("video.preview-video")).toBeVisible();
+  await expect(page.getByText("/ 00:10.02", { exact: false })).toBeVisible();
+  await expect(page.locator(".audio-clip.is-source")).toBeVisible({ timeout: 30_000 });
+  await page.locator(".image-clip").click();
+  await expect(page.getByRole("heading", { name: "画面", exact: true })).toBeVisible();
+  const scrubber = page.locator(".preview-stage .scrubber");
+  await scrubber.fill("1");
+
+  const fields = {
+    scale: page.getByRole("spinbutton", { name: "缩放 · 关键帧" }),
+    x: page.getByRole("spinbutton", { name: "水平位置 · 关键帧" }),
+    y: page.getByRole("spinbutton", { name: "垂直位置 · 关键帧" }),
+    rotation: page.getByRole("spinbutton", { name: "旋转 · 关键帧" }),
+    opacity: page.getByRole("spinbutton", { name: "不透明度 · 关键帧" }),
+  };
+  const addAll = page.getByRole("button", { name: "添加全部关键帧", exact: true });
+  await fields.scale.fill("120");
+  await fields.x.fill("20");
+  await fields.y.fill("-10");
+  await fields.rotation.fill("5");
+  await fields.opacity.fill("80");
+  await addAll.click();
+
+  await scrubber.fill("3");
+  await fields.scale.fill("160");
+  await fields.x.fill("60");
+  await fields.y.fill("30");
+  await fields.rotation.fill("25");
+  await fields.opacity.fill("40");
+  await addAll.click();
+  await expect(page.getByText(/2 帧/).first()).toBeVisible();
+  await page.getByRole("button", { name: "1.00s · 关键帧", exact: true }).click();
+  await expect(scrubber).toHaveValue("1");
+
+  await scrubber.fill("0");
+  await expect(fields.scale).toHaveValue("100");
+  await expect(fields.x).toHaveValue("0");
+  await expect(fields.y).toHaveValue("0");
+  await expect(fields.rotation).toHaveValue("0");
+  await expect(fields.opacity).toHaveValue("100");
+
+  await scrubber.fill("2");
+  await expect.poll(async () => Number(await fields.scale.inputValue())).toBeGreaterThan(135);
+  await expect.poll(async () => Number(await fields.scale.inputValue())).toBeLessThan(145);
+  await expect.poll(async () => Number(await fields.x.inputValue())).toBeGreaterThan(35);
+  await expect.poll(async () => Number(await fields.x.inputValue())).toBeLessThan(45);
+  await expect.poll(async () => Number(await fields.y.inputValue())).toBeGreaterThan(5);
+  await expect.poll(async () => Number(await fields.y.inputValue())).toBeLessThan(15);
+  await expect.poll(async () => Number(await fields.rotation.inputValue())).toBeGreaterThan(10);
+  await expect.poll(async () => Number(await fields.rotation.inputValue())).toBeLessThan(20);
+  await expect.poll(async () => Number(await fields.opacity.inputValue())).toBeGreaterThan(55);
+  await expect.poll(async () => Number(await fields.opacity.inputValue())).toBeLessThan(70);
+
+  const mediaStyle = await page.locator("video.preview-video").getAttribute("style");
+  expect(mediaStyle).toContain("translate(");
+  expect(mediaStyle).toContain("scale(");
+  expect(mediaStyle).toContain("rotate(");
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,6 +53,7 @@ import { createEditorCommandActions } from "./lib/editorCommandActions.js";
 import { createTimelineViewModel } from "./lib/timelineViewModel.js";
 import { createTranslator, getStoredLanguage, translateOptionName } from "./i18n.js";
 import { downloadBlob } from "./lib/media.js";
+import { removeVisualPropertyKeyframe, upsertVisualKeyframe, upsertVisualPropertyKeyframe } from "./lib/visualEffects.js";
 
 export function App() {
   const [uiLanguage, setUiLanguage] = useState(() => getStoredLanguage());
@@ -184,6 +185,24 @@ export function App() {
     trackVisibility, visionRecords, visualSegments, visualType,
   });
   const previewFrameSize = usePreviewFrameSize(previewShellRef, ratio, compactRail);
+  const selectedVisualSegment = visualSegments[selectedVisualSegmentIndex] ?? previewVisualSegment ?? null;
+  const selectedVisualRange = visualTimeline[selectedVisualSegmentIndex] ?? previewVisualRange;
+  const visualLocalTime = Math.max(0, Math.min(
+    selectedVisualSegment?.duration ?? 0,
+    currentTime - (selectedVisualRange?.start ?? 0),
+  ));
+  const updateSelectedVisualEffects = (change) => {
+    if (!selectedVisualSegment?.id || trackLocks.image) return notify("请先选择未锁定的 Visuals 片段");
+    setVisualSegments((items) => items.map((item) => {
+      if (item.id !== selectedVisualSegment.id) return item;
+      if (change.keyframe) return { ...item, keyframes: upsertVisualKeyframe(item.keyframes, change.keyframe.time, change.keyframe) };
+      if (change.propertyKeyframe) return { ...item, keyframes: upsertVisualPropertyKeyframe(item.keyframes, change.propertyKeyframe.time, change.propertyKeyframe.key, change.propertyKeyframe.value) };
+      if (change.removePropertyKeyframe) return { ...item, keyframes: removeVisualPropertyKeyframe(item.keyframes, change.removePropertyKeyframe.time, change.removePropertyKeyframe.key) };
+      if (Number.isFinite(change.removeKeyframeAt)) return { ...item, keyframes: (item.keyframes ?? []).filter((frame) => Math.abs(frame.time - change.removeKeyframeAt) > 0.04) };
+      if (change.mask) return { ...item, mask: change.mask };
+      return item;
+    }));
+  };
   const exportElapsedSeconds = useExportElapsed(exporting, exportStartRef);
   const {
     effectiveCaptionPlacement, previewSmartCropRect, previewVisionAnalysis,
@@ -546,6 +565,7 @@ export function App() {
           separateSourceVocals, vocalSeparationJob,
           toggleCaptionSegmentHidden, toggleVisionOption, trOption, updateCaptionSegmentText,
           updateScript, userAssets, visionJob,
+          selectedVisualSegment, visualLocalTime, updateSelectedVisualEffects,
         }} />
 
         <PreviewStage
@@ -558,6 +578,10 @@ export function App() {
           previewVisualRenderSrc={previewVisualRenderSrc}
           previewVisionMaskUrl={previewVisionMaskUrl}
           previewVisualType={previewVisualType}
+          visualEffects={previewVisualSegment}
+          visualLocalTime={previewVisualLocalTime}
+          visualMaskEditable={selectedTrack === "image" && Boolean(selectedVisualSegment)}
+          onUpdateVisualMask={(mask) => updateSelectedVisualEffects({ mask })}
           previewRatio={previewRatio}
           previewFrameStyle={previewFrameStyle}
           previewFrameSize={previewFrameSize}
@@ -665,6 +689,13 @@ export function App() {
           updateAudioSegment={updateAudioSegment}
           toggleAudioSegmentReverse={toggleAudioSegmentReverse}
           deleteAudioSegment={deleteAudioSegment}
+          selectedVisualSegment={selectedVisualSegment}
+          visualLocalTime={visualLocalTime}
+          visualTimelineStart={selectedVisualRange?.start ?? 0}
+          updateSelectedVisualEffects={updateSelectedVisualEffects}
+          selectedFilterId={selectedFilterId}
+          setSelectedFilterId={setSelectedFilterId}
+          trOption={trOption}
         />
       </section>
 

--- a/src/components/EditorSidebar.jsx
+++ b/src/components/EditorSidebar.jsx
@@ -108,6 +108,9 @@ export function EditorSidebar({ model: d }) {
             notify={d.notify}
             t={d.t}
             trOption={d.trOption}
+            selectedVisualSegment={d.selectedVisualSegment}
+            visualLocalTime={d.visualLocalTime}
+            updateSelectedVisualEffects={d.updateSelectedVisualEffects}
           />
         )}
       </aside>

--- a/src/components/PreviewStage.jsx
+++ b/src/components/PreviewStage.jsx
@@ -10,6 +10,7 @@ import {
 } from "@phosphor-icons/react";
 
 import { formatTime } from "../lib/timeline.js";
+import { getVisualMaskInsets, getVisualMaskSvgDataUrl, resolveVisualTransform } from "../lib/visualEffects.js";
 import { CaptionOverlay } from "./CaptionOverlay.jsx";
 import { IconButton } from "./ui.jsx";
 
@@ -53,12 +54,67 @@ export function PreviewStage({
   currentTime,
   seekTo,
   notify,
+  visualEffects,
+  visualLocalTime = 0,
+  visualMaskEditable = false,
+  onUpdateVisualMask,
 }) {
   const hasStickerOverlay = Boolean(selectedSticker?.src || selectedSticker?.text);
   const hasPreviewContent = Boolean(previewVisualSrc || hasStickerOverlay);
   const renderedVisualSrc = previewVisualRenderSrc || previewVisualSrc;
   const activeObjectFit = visualObjectFit || fitMode;
   const activeObjectPosition = visualObjectPosition || "50% 50%";
+  const visualTransform = resolveVisualTransform(visualEffects?.keyframes, visualLocalTime);
+  const visualMask = visualEffects?.mask ?? {};
+  const maskCenterX = Number.isFinite(visualMask.centerX) ? visualMask.centerX : 50;
+  const maskCenterY = Number.isFinite(visualMask.centerY) ? visualMask.centerY : 50;
+  const frameWidth = Math.max(1, previewFrameSize.width || 1);
+  const frameHeight = Math.max(1, previewFrameSize.height || 1);
+  const frameMinDimension = Math.min(frameWidth, frameHeight);
+  const circleSize = Number.isFinite(visualMask.size) ? visualMask.size : 72;
+  const maskWidth = visualMask.type === "circle" ? (circleSize * frameMinDimension) / frameWidth : Number.isFinite(visualMask.width) ? visualMask.width : 80;
+  const maskHeight = visualMask.type === "circle" ? (circleSize * frameMinDimension) / frameHeight : Number.isFinite(visualMask.height) ? visualMask.height : 80;
+  const shapeMaskUrl = getVisualMaskSvgDataUrl(visualMask, { width: frameWidth, height: frameHeight });
+  const usesAlphaMask = Boolean(shapeMaskUrl);
+  const maskInsets = getVisualMaskInsets(visualMask);
+  const roundedRadius = Math.min(maskWidth / 100 * frameWidth, maskHeight / 100 * frameHeight) * (Number.isFinite(visualMask.cornerRadius) ? visualMask.cornerRadius : 12) / 100;
+  const visualTransformStyle = {
+    transform: `translate(${visualTransform.x}%, ${visualTransform.y}%) scale(${visualTransform.scale}) rotate(${visualTransform.rotation}deg)`,
+    opacity: visualTransform.opacity,
+  };
+  const visualMaskStyle = {
+    clipPath: ["rectangle", "rounded"].includes(visualMask.type) && !usesAlphaMask
+      ? `inset(${maskInsets.top}% ${maskInsets.right}% ${maskInsets.bottom}% ${maskInsets.left}%${visualMask.type === "rounded" ? ` round ${roundedRadius}px` : ""})`
+      : visualMask.type === "circle" && !usesAlphaMask
+        ? `ellipse(${maskWidth / 2}% ${maskHeight / 2}% at ${maskCenterX}% ${maskCenterY}%)`
+        : undefined,
+    WebkitMaskImage: shapeMaskUrl ? `url("${shapeMaskUrl}")` : undefined,
+    maskImage: shapeMaskUrl ? `url("${shapeMaskUrl}")` : undefined,
+    WebkitMaskSize: shapeMaskUrl ? "100% 100%" : undefined,
+    maskSize: shapeMaskUrl ? "100% 100%" : undefined,
+    WebkitMaskRepeat: shapeMaskUrl ? "no-repeat" : undefined,
+    maskRepeat: shapeMaskUrl ? "no-repeat" : undefined,
+  };
+  const startMaskEdit = (event, mode) => {
+    const frame = previewCanvasRef.current;
+    if (!frame || !onUpdateVisualMask) return;
+    event.preventDefault(); event.stopPropagation();
+    const rect = frame.getBoundingClientRect();
+    const startX = event.clientX; const startY = event.clientY;
+    const initial = { centerX: maskCenterX, centerY: maskCenterY, width: maskWidth, height: maskHeight, size: circleSize };
+    const move = (moveEvent) => {
+      const dx = ((moveEvent.clientX - startX) / Math.max(1, rect.width)) * 100;
+      const dy = ((moveEvent.clientY - startY) / Math.max(1, rect.height)) * 100;
+      if (mode === "move") onUpdateVisualMask({ ...visualMask, centerX: Math.max(initial.width / 2, Math.min(100 - initial.width / 2, initial.centerX + dx)), centerY: Math.max(initial.height / 2, Math.min(100 - initial.height / 2, initial.centerY + dy)) });
+      else if (visualMask.type === "circle") {
+        const deltaPixels = Math.max(moveEvent.clientX - startX, moveEvent.clientY - startY);
+        const maxSizePixels = 2 * Math.min(initial.centerX / 100 * frameWidth, (100 - initial.centerX) / 100 * frameWidth, initial.centerY / 100 * frameHeight, (100 - initial.centerY) / 100 * frameHeight);
+        onUpdateVisualMask({ ...visualMask, size: Math.max(8, Math.min(maxSizePixels / frameMinDimension * 100, initial.size + deltaPixels / frameMinDimension * 100)) });
+      } else onUpdateVisualMask({ ...visualMask, width: Math.max(8, Math.min(2 * Math.min(initial.centerX, 100 - initial.centerX), initial.width + dx * 2)), height: Math.max(8, Math.min(2 * Math.min(initial.centerY, 100 - initial.centerY), initial.height + dy * 2)) });
+    };
+    const end = () => { window.removeEventListener("pointermove", move); window.removeEventListener("pointerup", end); };
+    window.addEventListener("pointermove", move); window.addEventListener("pointerup", end, { once: true });
+  };
 
   useEffect(() => {
     const video = previewVideoRef.current;
@@ -110,50 +166,36 @@ export function PreviewStage({
             data-hidden-label={t("imageHidden")}
             style={previewFrameStyle}
           >
-            {renderedVisualSrc && trackVisibility.image && previewVisualType === "image" ? (
-              <img
-                src={renderedVisualSrc}
-                alt={t("currentMediaAlt")}
-                style={{
-                  filter: selectedFilter.css,
-                  objectFit: activeObjectFit,
-                  objectPosition: activeObjectPosition,
-                }}
-              />
-            ) : null}
-            {previewVisualSrc && trackVisibility.image && previewVisualType === "video" ? (
-              <video
-                key={previewVisualSrc}
-                ref={previewVideoRef}
-                className="preview-video"
-                src={previewVisualSrc}
-                muted
-                playsInline
-                preload="metadata"
-                onTimeUpdate={(event) =>
-                  onPreviewVideoTimeUpdate?.(event.currentTarget.currentTime)
-                }
-                onSeeked={(event) =>
-                  onPreviewVideoTimeUpdate?.(event.currentTarget.currentTime)
-                }
-                style={{
-                  filter: selectedFilter.css,
-                  objectFit: activeObjectFit,
-                  objectPosition: activeObjectPosition,
-                  WebkitMaskImage: previewVisionMaskUrl
-                    ? `url("${previewVisionMaskUrl}")`
-                    : undefined,
-                  maskImage: previewVisionMaskUrl
-                    ? `url("${previewVisionMaskUrl}")`
-                    : undefined,
-                  WebkitMaskSize: previewVisionMaskUrl ? activeObjectFit : undefined,
-                  maskSize: previewVisionMaskUrl ? activeObjectFit : undefined,
-                  WebkitMaskPosition: previewVisionMaskUrl ? activeObjectPosition : undefined,
-                  maskPosition: previewVisionMaskUrl ? activeObjectPosition : undefined,
-                  WebkitMaskRepeat: previewVisionMaskUrl ? "no-repeat" : undefined,
-                  maskRepeat: previewVisionMaskUrl ? "no-repeat" : undefined,
-                }}
-              />
+            {renderedVisualSrc && trackVisibility.image ? (
+              <div className="visual-media-layer" style={visualMaskStyle}>
+                {previewVisualType === "image" ? <img
+                  src={renderedVisualSrc}
+                  alt={t("currentMediaAlt")}
+                  style={{ ...visualTransformStyle, filter: selectedFilter.css, objectFit: activeObjectFit, objectPosition: activeObjectPosition }}
+                /> : null}
+                {previewVisualType === "video" ? <video
+                  key={previewVisualSrc}
+                  ref={previewVideoRef}
+                  className="preview-video"
+                  src={previewVisualSrc}
+                  muted
+                  playsInline
+                  preload="metadata"
+                  onTimeUpdate={(event) => onPreviewVideoTimeUpdate?.(event.currentTarget.currentTime)}
+                  onSeeked={(event) => onPreviewVideoTimeUpdate?.(event.currentTarget.currentTime)}
+                  style={{
+                    ...visualTransformStyle, filter: selectedFilter.css, objectFit: activeObjectFit, objectPosition: activeObjectPosition,
+                    WebkitMaskImage: previewVisionMaskUrl ? `url("${previewVisionMaskUrl}")` : undefined,
+                    maskImage: previewVisionMaskUrl ? `url("${previewVisionMaskUrl}")` : undefined,
+                    WebkitMaskSize: previewVisionMaskUrl ? activeObjectFit : undefined,
+                    maskSize: previewVisionMaskUrl ? activeObjectFit : undefined,
+                    WebkitMaskPosition: previewVisionMaskUrl ? activeObjectPosition : undefined,
+                    maskPosition: previewVisionMaskUrl ? activeObjectPosition : undefined,
+                    WebkitMaskRepeat: previewVisionMaskUrl ? "no-repeat" : undefined,
+                    maskRepeat: previewVisionMaskUrl ? "no-repeat" : undefined,
+                  }}
+                /> : null}
+              </div>
             ) : null}
             {showVisionOverlays
               ? visionOverlayBoxes.map((detection, index) => (
@@ -179,6 +221,11 @@ export function PreviewStage({
                 {backgroundRemoved ? <span>MODNet</span> : null}
                 {smartCropActive ? <span>{t("smartVisionCrop")}</span> : null}
                 {captionAvoidanceActive ? <span>{t("smartVisionCaptionAvoidance")}</span> : null}
+              </div>
+            ) : null}
+            {visualMaskEditable && visualMask.type && visualMask.type !== "none" ? (
+              <div className={`visual-mask-editor is-${visualMask.type}`} style={{ left: `${maskCenterX - maskWidth / 2}%`, top: `${maskCenterY - maskHeight / 2}%`, width: `${maskWidth}%`, height: `${maskHeight}%`, borderRadius: visualMask.type === "rounded" ? `${roundedRadius}px` : undefined }} onPointerDown={(event) => startMaskEdit(event, "move")}>
+                <span>{t("visualMask")}</span><button type="button" aria-label={t("visualMaskResize")} onPointerDown={(event) => startMaskEdit(event, "resize")} />
               </div>
             ) : null}
             {captionsEnabled && trackVisibility.caption && currentCaption ? (

--- a/src/components/VoicePanel.jsx
+++ b/src/components/VoicePanel.jsx
@@ -13,7 +13,8 @@ import { useState } from "react";
 import { formatTime, getSegmentStartTime } from "../lib/timeline.js";
 import { LIVE_PORTRAIT_WEB_MODEL } from "../config/livePortrait.js";
 import { probeLivePortraitWebEnvironment } from "../lib/livePortraitWeb.js";
-import { HistoryPanel, MyVoicesPanel, VoiceSynthesisPanel } from "./panels.jsx";
+import { normalizeVisualKeyframes } from "../lib/visualEffects.js";
+import { HistoryPanel, MyVoicesPanel, VisualEffectsPanel, VoiceSynthesisPanel } from "./panels.jsx";
 
 function CaptionContextPanel({
   t,
@@ -314,15 +315,25 @@ export function VoicePanel({
   updateAudioSegment,
   toggleAudioSegmentReverse,
   deleteAudioSegment,
+  selectedVisualSegment,
+  visualLocalTime,
+  visualTimelineStart = 0,
+  updateSelectedVisualEffects,
+  selectedFilterId,
+  setSelectedFilterId,
+  trOption,
 }) {
   const isCaptionContext = activeTool === "caption";
   const isAvatarContext = activeTool === "smart" && avatarPanelOpen;
   const isAudioClipContext = selectedTrack === "audio" && Boolean(selectedAudioSegment);
-  const title = isAvatarContext ? t("avatarTitle") : isCaptionContext ? t("caption") : isAudioClipContext ? t("audioClipProperties") : t("aiVoice");
+  const isVisualContext = selectedTrack === "image" && Boolean(selectedVisualSegment);
+  const title = isVisualContext ? t("imageTrack") : isAvatarContext ? t("avatarTitle") : isCaptionContext ? t("caption") : isAudioClipContext ? t("audioClipProperties") : t("aiVoice");
   const panelStatusText = isCaptionContext
     ? captionSegments.length
       ? `${captionSegments.length} ${t("captionSegmentsUnit", "条字幕")}`
       : t("noCaptionSegments")
+    : isVisualContext
+      ? `${visualLocalTime.toFixed(2)}s · ${normalizeVisualKeyframes(selectedVisualSegment.keyframes).length} ${t("visualFrames")}`
     : isAvatarContext
       ? t("avatarPortingStatus")
     : isAudioClipContext
@@ -332,7 +343,7 @@ export function VoicePanel({
       : statusText;
 
   return (
-    <aside className={`voice-panel ${isCaptionContext ? "is-caption-context" : ""} ${isAvatarContext ? "is-avatar-context" : ""} ${isAudioClipContext ? "is-audio-clip-context" : ""}`}>
+    <aside className={`voice-panel ${isCaptionContext ? "is-caption-context" : ""} ${isAvatarContext ? "is-avatar-context" : ""} ${isAudioClipContext ? "is-audio-clip-context" : ""} ${isVisualContext ? "is-visual-context" : ""}`}>
       <div className="panel-title-row">
         <h1>{title}</h1>
         <span className={`status-pill ${isCaptionContext ? "done" : status}`}>
@@ -340,7 +351,7 @@ export function VoicePanel({
         </span>
       </div>
 
-      {!isCaptionContext && !isAvatarContext && !isAudioClipContext ? (
+      {!isCaptionContext && !isAvatarContext && !isAudioClipContext && !isVisualContext ? (
         <div className="tabs compact">
           {[
             ["synthesis", t("voiceSynthesis")],
@@ -360,6 +371,19 @@ export function VoicePanel({
       ) : null}
 
       <div className="voice-tab-body">
+        {isVisualContext ? (
+          <VisualEffectsPanel
+            contextMode
+            t={t}
+            segment={selectedVisualSegment}
+            localTime={visualLocalTime}
+            onChange={updateSelectedVisualEffects}
+            onSeek={(time) => seekTo(visualTimelineStart + time)}
+            selectedFilterId={selectedFilterId}
+            trOption={trOption}
+            onSelectFilter={(id) => { setSelectedFilterId(id); notify(t("effectApplied")); }}
+          />
+        ) : null}
         {isCaptionContext ? (
           <CaptionContextPanel
             t={t}
@@ -384,7 +408,7 @@ export function VoicePanel({
 
         {isAudioClipContext ? <AudioClipContextPanel t={t} segment={selectedAudioSegment} updateAudioSegment={updateAudioSegment} toggleAudioSegmentReverse={toggleAudioSegmentReverse} deleteAudioSegment={deleteAudioSegment} downloadBlob={downloadBlob} /> : null}
 
-        {!isCaptionContext && !isAvatarContext && !isAudioClipContext && voiceTab === "synthesis" ? (
+        {!isCaptionContext && !isAvatarContext && !isAudioClipContext && !isVisualContext && voiceTab === "synthesis" ? (
           <VoiceSynthesisPanel
             script={script}
             updateScript={updateScript}
@@ -411,7 +435,7 @@ export function VoicePanel({
           />
         ) : null}
 
-        {!isCaptionContext && !isAvatarContext && !isAudioClipContext && voiceTab === "mine" ? (
+        {!isCaptionContext && !isAvatarContext && !isAudioClipContext && !isVisualContext && voiceTab === "mine" ? (
           <MyVoicesPanel
             favoriteVoiceIds={favoriteVoiceIds}
             setFavoriteVoiceIds={setFavoriteVoiceIds}
@@ -429,7 +453,7 @@ export function VoicePanel({
           />
         ) : null}
 
-        {!isCaptionContext && !isAvatarContext && !isAudioClipContext && voiceTab === "history" ? (
+        {!isCaptionContext && !isAvatarContext && !isAudioClipContext && !isVisualContext && voiceTab === "history" ? (
           <HistoryPanel
             historyItems={historyItems}
             useHistoryItem={useHistoryItem}

--- a/src/components/panels.jsx
+++ b/src/components/panels.jsx
@@ -7,6 +7,7 @@ import {
   CloudArrowUp,
   ClosedCaptioning,
   Crop,
+  Diamond,
   DownloadSimple,
   MicrophoneStage,
   MusicNote,
@@ -31,6 +32,7 @@ import {
 } from "../config/editor.js";
 import { APP_LANGUAGES } from "../i18n.js";
 import { formatClock, formatTime, getSegmentStartTime } from "../lib/timeline.js";
+import { hasVisualPropertyKeyframe, normalizeVisualKeyframes, resolveVisualTransform } from "../lib/visualEffects.js";
 import { Popover } from "./ui.jsx";
 
 export function LanguageIntro({ t, closing, onChoose }) {
@@ -276,6 +278,9 @@ export function ToolPanel(props) {
     notify,
     t,
     trOption,
+    selectedVisualSegment,
+    visualLocalTime,
+    updateSelectedVisualEffects,
   } = props;
 
   if (activeTool === "text") {
@@ -537,16 +542,14 @@ export function ToolPanel(props) {
 
   if (activeTool === "effects") {
     return (
-      <VisualChoicePanel
-        title={t("effects")}
-        kind="effect"
-        options={EFFECT_OPTIONS}
-        selectedId={selectedFilterId}
+      <VisualEffectsPanel
+        t={t}
+        segment={selectedVisualSegment}
+        localTime={visualLocalTime}
+        onChange={updateSelectedVisualEffects}
+        selectedFilterId={selectedFilterId}
         trOption={trOption}
-        onSelect={(id) => {
-          setSelectedFilterId(id);
-          notify(t("effectApplied"));
-        }}
+        onSelectFilter={(id) => { setSelectedFilterId(id); notify(t("effectApplied")); }}
       />
     );
   }
@@ -581,6 +584,45 @@ export function ToolPanel(props) {
         notify(t("filterApplied"));
       }}
     />
+  );
+}
+
+export function VisualEffectsPanel({ t, segment, localTime, onChange, onSeek, selectedFilterId, trOption, onSelectFilter, contextMode = false }) {
+  const keyframes = normalizeVisualKeyframes(segment?.keyframes ?? []);
+  const transform = resolveVisualTransform(keyframes, localTime);
+  const mask = segment?.mask ?? { type: "none", feather: 0, inverted: false };
+  const hasMask = mask.type && mask.type !== "none";
+  const isCircleMask = mask.type === "circle";
+  const updateTransform = (key, value) => onChange?.({ propertyKeyframe: { time: localTime, key, value } });
+  return (
+    <div className={`tool-panel visual-effects-panel ${contextMode ? "is-context-mode" : ""}`}>
+      {!contextMode ? <h2>{t("imageTrack")}</h2> : null}
+      {!segment ? <div className="empty-state">{t("visualSelectClip")}</div> : <>
+        <section className="visual-editor-card">
+          <div className="visual-editor-heading"><span><Diamond size={16} weight="fill" />{t("visualKeyframes")}</span><em>{localTime.toFixed(2)}s · {keyframes.length} {t("visualFrames")}</em></div>
+          <button className="panel-secondary visual-add-all-keyframes" type="button" onClick={() => onChange?.({ keyframe: { time: localTime, ...transform } })}><Diamond size={14} weight="fill" />{t("visualAddAllKeyframes")}</button>
+          {keyframes.length ? <div className="visual-keyframe-times" aria-label={t("visualKeyframes")}>{keyframes.map((frame) => <button type="button" aria-label={`${frame.time.toFixed(2)}s · ${t("visualKeyframes")}`} className={Math.abs(frame.time - localTime) <= 0.04 ? "is-current" : ""} key={frame.time} onClick={() => onSeek?.(frame.time)}>{frame.time.toFixed(2)}s</button>)}</div> : null}
+          {[['scale', t('visualScale'), 0.2, 3, 0.01, 100], ['x', t('visualPositionX'), -100, 100, 1, 1], ['y', t('visualPositionY'), -100, 100, 1, 1], ['rotation', t('visualRotation'), -180, 180, 1, 1], ['opacity', t('visualOpacity'), 0, 1, 0.01, 100]].map(([key, label, min, max, step, displayScale]) => {
+            const keyed = hasVisualPropertyKeyframe(keyframes, localTime, key);
+            const displayValue = Math.round(transform[key] * displayScale * 100) / 100;
+            return <div className="slider-field compact-slider visual-keyframe-property" key={key}><div><label>{label}</label><span className="visual-property-value"><label className="visual-number-field"><input aria-label={`${label} · ${t("visualKeyframes")}`} type="number" min={min * displayScale} max={max * displayScale} step={step * displayScale} value={displayValue} onChange={(event) => updateTransform(key, Number(event.target.value) / displayScale)} /><i>{key === 'rotation' ? '°' : '%'}</i></label><button className={keyed ? "is-active" : ""} type="button" aria-label={`${keyed ? t("visualRemovePropertyKeyframe") : t("visualAddPropertyKeyframe")} · ${label}`} onClick={() => keyed ? onChange?.({ removePropertyKeyframe: { time: localTime, key } }) : onChange?.({ propertyKeyframe: { time: localTime, key, value: transform[key] } })}><Diamond size={13} weight={keyed ? "fill" : "regular"} /></button></span></div><input aria-label={`${label} · slider`} type="range" min={min} max={max} step={step} value={transform[key]} onChange={(event) => updateTransform(key, Number(event.target.value))} /></div>;
+          })}
+          <button className="panel-secondary" type="button" onClick={() => onChange?.({ removeKeyframeAt: localTime })}>{t("visualDeleteKeyframe")}</button>
+        </section>
+        <section className="visual-editor-card">
+          <div className="visual-editor-heading"><strong>{t("visualMask")}</strong><em>{t("visualClipScoped")}</em></div>
+          <div className="mask-choice-grid">{[['none',t('visualMaskNone')],['rectangle',t('visualMaskRectangle')],['rounded',t('visualMaskRounded')],['circle',t('visualMaskCircle')]].map(([id,label]) => <button type="button" key={id} className={mask.type === id ? 'is-active' : ''} onClick={() => onChange?.({ mask: { ...mask, type: id, ...(id === 'circle' && !Number.isFinite(mask.size) ? { size: 72 } : {}), ...(id === 'rounded' && !Number.isFinite(mask.cornerRadius) ? { cornerRadius: 12 } : {}) } })}>{label}</button>)}</div>
+          {hasMask ? <>
+            <div className="slider-field compact-slider"><div><label>{t("visualFeather")}</label><span>{mask.feather || 0}%</span></div><input type="range" min="0" max="40" value={mask.feather || 0} onChange={(event) => onChange?.({ mask: { ...mask, feather: Number(event.target.value) } })} /></div>
+            {[['centerX',t('visualHorizontal'),0,100,50],['centerY',t('visualVertical'),0,100,50]].map(([key,label,min,max,fallback]) => <div className="slider-field compact-slider" key={key}><div><label>{label}</label><span>{Number.isFinite(mask[key]) ? Math.round(mask[key]) : fallback}%</span></div><input type="range" min={min} max={max} value={Number.isFinite(mask[key]) ? mask[key] : fallback} onChange={(event) => onChange?.({ mask: { ...mask, [key]: Number(event.target.value) } })} /></div>)}
+            {isCircleMask ? <div className="slider-field compact-slider"><div><label>{t("visualDiameter")}</label><span>{Number.isFinite(mask.size) ? Math.round(mask.size) : 72}%</span></div><input type="range" min="8" max="100" value={Number.isFinite(mask.size) ? mask.size : 72} onChange={(event) => onChange?.({ mask: { ...mask, size: Number(event.target.value) } })} /></div> : [['width',t('visualWidth'),8,100,80],['height',t('visualHeight'),8,100,80]].map(([key,label,min,max,fallback]) => <div className="slider-field compact-slider" key={key}><div><label>{label}</label><span>{Number.isFinite(mask[key]) ? Math.round(mask[key]) : fallback}%</span></div><input type="range" min={min} max={max} value={Number.isFinite(mask[key]) ? mask[key] : fallback} onChange={(event) => onChange?.({ mask: { ...mask, [key]: Number(event.target.value) } })} /></div>)}
+            {mask.type === "rounded" ? <div className="slider-field compact-slider"><div><label>{t("visualCornerRadius")}</label><span>{Number.isFinite(mask.cornerRadius) ? Math.round(mask.cornerRadius) : 12}%</span></div><input type="range" min="0" max="50" value={Number.isFinite(mask.cornerRadius) ? mask.cornerRadius : 12} onChange={(event) => onChange?.({ mask: { ...mask, cornerRadius: Number(event.target.value) } })} /></div> : null}
+            <label className="switch-row"><input type="checkbox" checked={Boolean(mask.inverted)} onChange={(event) => onChange?.({ mask: { ...mask, inverted: event.target.checked } })} />{t("visualInvertMask")}</label>
+          </> : <p className="mask-empty-hint">{t("visualMaskNoneHint")}</p>}
+        </section>
+      </>}
+      <VisualChoicePanel title={t("visualEffects")} kind="effect" options={EFFECT_OPTIONS} selectedId={selectedFilterId} trOption={trOption} onSelect={onSelectFilter} />
+    </div>
   );
 }
 

--- a/src/config/editor.js
+++ b/src/config/editor.js
@@ -5,7 +5,6 @@ import {
   MagicWand,
   MusicNote,
   Scan,
-  Sparkle,
   Sticker,
   TextT,
 } from "@phosphor-icons/react";
@@ -158,7 +157,6 @@ export const TOOL_RAIL = [
   { id: "smart", label: "智能", icon: Scan },
   { id: "audio", label: "音频", icon: MusicNote },
   { id: "transition", label: "转场", icon: CirclesThree },
-  { id: "effects", label: "效果", icon: Sparkle },
   { id: "stickers", label: "贴纸", icon: Sticker },
   { id: "filters", label: "滤镜", icon: MagicWand },
 ];

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -13,8 +13,50 @@ export const APP_LANGUAGES = [
   { id: "vi", name: "Vietnamese", nativeName: "Tiếng Việt", hint: "Vietnamese" },
 ];
 
+const VISUAL_EDITOR_COPY = {
+  zh: { visualSelectClip: "请先选择 Visuals 轨上的片段", visualKeyframes: "关键帧", visualFrames: "帧", visualScale: "缩放", visualPositionX: "水平位置", visualPositionY: "垂直位置", visualRotation: "旋转", visualOpacity: "不透明度", visualDeleteKeyframe: "删除当前位置关键帧", visualMask: "蒙版", visualMaskResize: "调整蒙版大小", visualClipScoped: "片段级", visualMaskNone: "无", visualMaskRectangle: "矩形", visualMaskRounded: "圆角", visualMaskCircle: "圆形", visualFeather: "羽化", visualHorizontal: "水平", visualVertical: "垂直", visualWidth: "宽度", visualHeight: "高度", visualDiameter: "直径", visualCornerRadius: "圆角半径", visualMaskNoneHint: "选择一种蒙版后显示对应参数", visualInvertMask: "反向蒙版", visualEffects: "画面效果" },
+  en: { visualSelectClip: "Select a clip on the Visuals track", visualKeyframes: "Keyframes", visualFrames: "frames", visualScale: "Scale", visualPositionX: "Horizontal position", visualPositionY: "Vertical position", visualRotation: "Rotation", visualOpacity: "Opacity", visualDeleteKeyframe: "Delete keyframe at playhead", visualMask: "Mask", visualMaskResize: "Resize mask", visualClipScoped: "Clip", visualMaskNone: "None", visualMaskRectangle: "Rectangle", visualMaskRounded: "Rounded", visualMaskCircle: "Circle", visualFeather: "Feather", visualHorizontal: "Horizontal", visualVertical: "Vertical", visualWidth: "Width", visualHeight: "Height", visualDiameter: "Diameter", visualCornerRadius: "Corner radius", visualMaskNoneHint: "Choose a mask to show its parameters", visualInvertMask: "Invert mask", visualEffects: "Visual effects" },
+  ja: { visualSelectClip: "Visualsトラックのクリップを選択してください", visualKeyframes: "キーフレーム", visualFrames: "フレーム", visualScale: "拡大率", visualPositionX: "水平位置", visualPositionY: "垂直位置", visualRotation: "回転", visualOpacity: "不透明度", visualDeleteKeyframe: "現在位置のキーフレームを削除", visualMask: "マスク", visualMaskResize: "マスクのサイズを変更", visualClipScoped: "クリップ", visualMaskNone: "なし", visualMaskRectangle: "長方形", visualMaskRounded: "角丸", visualMaskCircle: "円形", visualFeather: "ぼかし", visualHorizontal: "水平", visualVertical: "垂直", visualWidth: "幅", visualHeight: "高さ", visualInvertMask: "マスクを反転", visualEffects: "映像エフェクト" },
+  ko: { visualSelectClip: "Visuals 트랙에서 클립을 선택하세요", visualKeyframes: "키프레임", visualFrames: "프레임", visualScale: "크기", visualPositionX: "가로 위치", visualPositionY: "세로 위치", visualRotation: "회전", visualOpacity: "불투명도", visualDeleteKeyframe: "현재 위치 키프레임 삭제", visualMask: "마스크", visualMaskResize: "마스크 크기 조절", visualClipScoped: "클립", visualMaskNone: "없음", visualMaskRectangle: "사각형", visualMaskRounded: "둥근 모서리", visualMaskCircle: "원형", visualFeather: "페더", visualHorizontal: "가로", visualVertical: "세로", visualWidth: "너비", visualHeight: "높이", visualInvertMask: "마스크 반전", visualEffects: "화면 효과" },
+  es: { visualSelectClip: "Selecciona un clip en la pista Visuals", visualKeyframes: "Fotogramas clave", visualFrames: "fotogramas", visualScale: "Escala", visualPositionX: "Posición horizontal", visualPositionY: "Posición vertical", visualRotation: "Rotación", visualOpacity: "Opacidad", visualDeleteKeyframe: "Eliminar fotograma clave actual", visualMask: "Máscara", visualMaskResize: "Cambiar tamaño de máscara", visualClipScoped: "Clip", visualMaskNone: "Ninguna", visualMaskRectangle: "Rectángulo", visualMaskRounded: "Redondeada", visualMaskCircle: "Círculo", visualFeather: "Desvanecer", visualHorizontal: "Horizontal", visualVertical: "Vertical", visualWidth: "Ancho", visualHeight: "Alto", visualInvertMask: "Invertir máscara", visualEffects: "Efectos visuales" },
+  fr: { visualSelectClip: "Sélectionnez un clip sur la piste Visuals", visualKeyframes: "Images clés", visualFrames: "images", visualScale: "Échelle", visualPositionX: "Position horizontale", visualPositionY: "Position verticale", visualRotation: "Rotation", visualOpacity: "Opacité", visualDeleteKeyframe: "Supprimer l’image clé actuelle", visualMask: "Masque", visualMaskResize: "Redimensionner le masque", visualClipScoped: "Clip", visualMaskNone: "Aucun", visualMaskRectangle: "Rectangle", visualMaskRounded: "Arrondi", visualMaskCircle: "Cercle", visualFeather: "Contour progressif", visualHorizontal: "Horizontal", visualVertical: "Vertical", visualWidth: "Largeur", visualHeight: "Hauteur", visualInvertMask: "Inverser le masque", visualEffects: "Effets visuels" },
+  de: { visualSelectClip: "Clip in der Visuals-Spur auswählen", visualKeyframes: "Keyframes", visualFrames: "Frames", visualScale: "Skalierung", visualPositionX: "Horizontale Position", visualPositionY: "Vertikale Position", visualRotation: "Drehung", visualOpacity: "Deckkraft", visualDeleteKeyframe: "Keyframe an Abspielposition löschen", visualMask: "Maske", visualMaskResize: "Maskengröße ändern", visualClipScoped: "Clip", visualMaskNone: "Keine", visualMaskRectangle: "Rechteck", visualMaskRounded: "Abgerundet", visualMaskCircle: "Kreis", visualFeather: "Weiche Kante", visualHorizontal: "Horizontal", visualVertical: "Vertikal", visualWidth: "Breite", visualHeight: "Höhe", visualInvertMask: "Maske umkehren", visualEffects: "Bildeffekte" },
+  pt: { visualSelectClip: "Selecione um clipe na faixa Visuals", visualKeyframes: "Quadros-chave", visualFrames: "quadros", visualScale: "Escala", visualPositionX: "Posição horizontal", visualPositionY: "Posição vertical", visualRotation: "Rotação", visualOpacity: "Opacidade", visualDeleteKeyframe: "Excluir quadro-chave atual", visualMask: "Máscara", visualMaskResize: "Redimensionar máscara", visualClipScoped: "Clipe", visualMaskNone: "Nenhuma", visualMaskRectangle: "Retângulo", visualMaskRounded: "Arredondada", visualMaskCircle: "Círculo", visualFeather: "Suavização", visualHorizontal: "Horizontal", visualVertical: "Vertical", visualWidth: "Largura", visualHeight: "Altura", visualInvertMask: "Inverter máscara", visualEffects: "Efeitos visuais" },
+  th: { visualSelectClip: "เลือกคลิปในแทร็ก Visuals", visualKeyframes: "คีย์เฟรม", visualFrames: "เฟรม", visualScale: "ขนาด", visualPositionX: "ตำแหน่งแนวนอน", visualPositionY: "ตำแหน่งแนวตั้ง", visualRotation: "การหมุน", visualOpacity: "ความทึบ", visualDeleteKeyframe: "ลบคีย์เฟรมที่ตำแหน่งปัจจุบัน", visualMask: "มาสก์", visualMaskResize: "ปรับขนาดมาสก์", visualClipScoped: "คลิป", visualMaskNone: "ไม่มี", visualMaskRectangle: "สี่เหลี่ยม", visualMaskRounded: "มุมมน", visualMaskCircle: "วงกลม", visualFeather: "ขอบฟุ้ง", visualHorizontal: "แนวนอน", visualVertical: "แนวตั้ง", visualWidth: "ความกว้าง", visualHeight: "ความสูง", visualInvertMask: "กลับด้านมาสก์", visualEffects: "เอฟเฟกต์ภาพ" },
+  vi: { visualSelectClip: "Chọn một clip trên rãnh Visuals", visualKeyframes: "Khung hình chính", visualFrames: "khung", visualScale: "Tỷ lệ", visualPositionX: "Vị trí ngang", visualPositionY: "Vị trí dọc", visualRotation: "Xoay", visualOpacity: "Độ mờ", visualDeleteKeyframe: "Xóa khung hình chính hiện tại", visualMask: "Mặt nạ", visualMaskResize: "Đổi kích thước mặt nạ", visualClipScoped: "Clip", visualMaskNone: "Không", visualMaskRectangle: "Chữ nhật", visualMaskRounded: "Bo góc", visualMaskCircle: "Tròn", visualFeather: "Làm mềm", visualHorizontal: "Ngang", visualVertical: "Dọc", visualWidth: "Rộng", visualHeight: "Cao", visualInvertMask: "Đảo mặt nạ", visualEffects: "Hiệu ứng hình ảnh" },
+};
+
+const VISUAL_MASK_SHAPE_COPY = {
+  zh: { visualDiameter: "直径", visualCornerRadius: "圆角半径", visualMaskNoneHint: "选择一种蒙版后显示对应参数" },
+  en: { visualDiameter: "Diameter", visualCornerRadius: "Corner radius", visualMaskNoneHint: "Choose a mask to show its parameters" },
+  ja: { visualDiameter: "直径", visualCornerRadius: "角丸の半径", visualMaskNoneHint: "マスクを選ぶと対応する設定が表示されます" },
+  ko: { visualDiameter: "지름", visualCornerRadius: "모서리 반경", visualMaskNoneHint: "마스크를 선택하면 해당 매개변수가 표시됩니다" },
+  es: { visualDiameter: "Diámetro", visualCornerRadius: "Radio de esquina", visualMaskNoneHint: "Elige una máscara para ver sus parámetros" },
+  fr: { visualDiameter: "Diamètre", visualCornerRadius: "Rayon des coins", visualMaskNoneHint: "Choisissez un masque pour afficher ses paramètres" },
+  de: { visualDiameter: "Durchmesser", visualCornerRadius: "Eckenradius", visualMaskNoneHint: "Maske auswählen, um ihre Parameter anzuzeigen" },
+  pt: { visualDiameter: "Diâmetro", visualCornerRadius: "Raio do canto", visualMaskNoneHint: "Escolha uma máscara para exibir seus parâmetros" },
+  th: { visualDiameter: "เส้นผ่านศูนย์กลาง", visualCornerRadius: "รัศมีมุม", visualMaskNoneHint: "เลือกมาสก์เพื่อแสดงพารามิเตอร์" },
+  vi: { visualDiameter: "Đường kính", visualCornerRadius: "Bán kính góc", visualMaskNoneHint: "Chọn mặt nạ để hiển thị các tham số" },
+};
+
+const VISUAL_KEYFRAME_ACTION_COPY = {
+  zh: { visualAddAllKeyframes: "添加全部关键帧", visualAddPropertyKeyframe: "添加属性关键帧", visualRemovePropertyKeyframe: "移除属性关键帧" },
+  en: { visualAddAllKeyframes: "Add all keyframes", visualAddPropertyKeyframe: "Add property keyframe", visualRemovePropertyKeyframe: "Remove property keyframe" },
+  ja: { visualAddAllKeyframes: "すべてのキーフレームを追加", visualAddPropertyKeyframe: "プロパティのキーフレームを追加", visualRemovePropertyKeyframe: "プロパティのキーフレームを削除" },
+  ko: { visualAddAllKeyframes: "모든 키프레임 추가", visualAddPropertyKeyframe: "속성 키프레임 추가", visualRemovePropertyKeyframe: "속성 키프레임 제거" },
+  es: { visualAddAllKeyframes: "Añadir todos los fotogramas clave", visualAddPropertyKeyframe: "Añadir fotograma clave de propiedad", visualRemovePropertyKeyframe: "Quitar fotograma clave de propiedad" },
+  fr: { visualAddAllKeyframes: "Ajouter toutes les images clés", visualAddPropertyKeyframe: "Ajouter l’image clé de la propriété", visualRemovePropertyKeyframe: "Supprimer l’image clé de la propriété" },
+  de: { visualAddAllKeyframes: "Alle Keyframes hinzufügen", visualAddPropertyKeyframe: "Eigenschafts-Keyframe hinzufügen", visualRemovePropertyKeyframe: "Eigenschafts-Keyframe entfernen" },
+  pt: { visualAddAllKeyframes: "Adicionar todos os quadros-chave", visualAddPropertyKeyframe: "Adicionar quadro-chave da propriedade", visualRemovePropertyKeyframe: "Remover quadro-chave da propriedade" },
+  th: { visualAddAllKeyframes: "เพิ่มคีย์เฟรมทั้งหมด", visualAddPropertyKeyframe: "เพิ่มคีย์เฟรมคุณสมบัติ", visualRemovePropertyKeyframe: "ลบคีย์เฟรมคุณสมบัติ" },
+  vi: { visualAddAllKeyframes: "Thêm tất cả khung hình chính", visualAddPropertyKeyframe: "Thêm khung hình chính thuộc tính", visualRemovePropertyKeyframe: "Xóa khung hình chính thuộc tính" },
+};
+
 export const UI_COPY = {
   zh: {
+    ...VISUAL_EDITOR_COPY.zh,
+    ...VISUAL_MASK_SHAPE_COPY.zh,
+    ...VISUAL_KEYFRAME_ACTION_COPY.zh,
     languageKicker: "AI Voice Studio",
     languageTitle: "选择界面语言",
     languageSubtitle: "设置一次后会自动保存，下次进入直接使用该语言。",
@@ -351,6 +393,9 @@ export const UI_COPY = {
     dropMusicHere: "释放到背景音乐轨",
   },
   en: {
+    ...VISUAL_EDITOR_COPY.en,
+    ...VISUAL_MASK_SHAPE_COPY.en,
+    ...VISUAL_KEYFRAME_ACTION_COPY.en,
     languageKicker: "AI Voice Studio",
     languageTitle: "Choose Interface Language",
     languageSubtitle: "Saved once, then this editor opens in your language next time.",
@@ -687,6 +732,9 @@ export const UI_COPY = {
     dropMusicHere: "Drop on music track",
   },
   ja: {
+    ...VISUAL_EDITOR_COPY.ja,
+    ...VISUAL_MASK_SHAPE_COPY.ja,
+    ...VISUAL_KEYFRAME_ACTION_COPY.ja,
     languageTitle: "表示言語を選択",
     languageSubtitle: "一度保存すると、次回からこの言語で開きます。",
     languageSaved: "あとで設定から変更できます",
@@ -749,6 +797,9 @@ export const UI_COPY = {
 
 Object.assign(UI_COPY, {
   ko: {
+    ...VISUAL_EDITOR_COPY.ko,
+    ...VISUAL_MASK_SHAPE_COPY.ko,
+    ...VISUAL_KEYFRAME_ACTION_COPY.ko,
     ...UI_COPY.en,
     languageTitle: "인터페이스 언어 선택",
     languageSubtitle: "한 번 저장하면 다음부터 이 언어로 열립니다.",
@@ -791,6 +842,9 @@ Object.assign(UI_COPY, {
   },
   es: {
     ...UI_COPY.en,
+    ...VISUAL_EDITOR_COPY.es,
+    ...VISUAL_MASK_SHAPE_COPY.es,
+    ...VISUAL_KEYFRAME_ACTION_COPY.es,
     languageTitle: "Elige el idioma",
     languageSubtitle: "Se guarda una vez y se abrirá así la próxima vez.",
     languageSaved: "Puedes cambiarlo luego en Ajustes",
@@ -832,6 +886,9 @@ Object.assign(UI_COPY, {
   },
   fr: {
     ...UI_COPY.en,
+    ...VISUAL_EDITOR_COPY.fr,
+    ...VISUAL_MASK_SHAPE_COPY.fr,
+    ...VISUAL_KEYFRAME_ACTION_COPY.fr,
     languageTitle: "Choisir la langue",
     languageSubtitle: "Enregistrée une fois, elle sera utilisée à la prochaine ouverture.",
     languageSaved: "Modifiable plus tard dans les réglages",
@@ -873,6 +930,9 @@ Object.assign(UI_COPY, {
   },
   de: {
     ...UI_COPY.en,
+    ...VISUAL_EDITOR_COPY.de,
+    ...VISUAL_MASK_SHAPE_COPY.de,
+    ...VISUAL_KEYFRAME_ACTION_COPY.de,
     languageTitle: "Sprache wählen",
     languageSubtitle: "Einmal gespeichert, startet der Editor künftig in dieser Sprache.",
     languageSaved: "Später in den Einstellungen änderbar",
@@ -914,6 +974,9 @@ Object.assign(UI_COPY, {
   },
   pt: {
     ...UI_COPY.en,
+    ...VISUAL_EDITOR_COPY.pt,
+    ...VISUAL_MASK_SHAPE_COPY.pt,
+    ...VISUAL_KEYFRAME_ACTION_COPY.pt,
     languageTitle: "Escolha o idioma",
     languageSubtitle: "Salvo uma vez, o editor abrirá nesse idioma depois.",
     languageSaved: "Você pode alterar em Configurações",
@@ -955,6 +1018,9 @@ Object.assign(UI_COPY, {
   },
   th: {
     ...UI_COPY.en,
+    ...VISUAL_EDITOR_COPY.th,
+    ...VISUAL_MASK_SHAPE_COPY.th,
+    ...VISUAL_KEYFRAME_ACTION_COPY.th,
     languageTitle: "เลือกภาษาอินเทอร์เฟซ",
     languageSubtitle: "บันทึกครั้งเดียว ครั้งถัดไปจะเปิดด้วยภาษานี้",
     languageSaved: "เปลี่ยนได้ภายหลังใน Settings",
@@ -996,6 +1062,9 @@ Object.assign(UI_COPY, {
   },
   vi: {
     ...UI_COPY.en,
+    ...VISUAL_EDITOR_COPY.vi,
+    ...VISUAL_MASK_SHAPE_COPY.vi,
+    ...VISUAL_KEYFRAME_ACTION_COPY.vi,
     languageTitle: "Chọn ngôn ngữ giao diện",
     languageSubtitle: "Lưu một lần, lần sau sẽ mở bằng ngôn ngữ này.",
     languageSaved: "Có thể đổi lại trong Cài đặt",

--- a/src/lib/media.js
+++ b/src/lib/media.js
@@ -17,6 +17,7 @@ import {
 } from "./captionLayout.js";
 import { resolveVisionAnalysisAtTime } from "./vision.js";
 import { getCaptionAvoidancePlacement, getSmartCropRect } from "./visualGeometry.js";
+import { getVisualMaskFeatherPixels, getVisualMaskGeometry, resolveVisualTransform } from "./visualEffects.js";
 
 export function getAudioRecordingFormat() {
   if (typeof MediaRecorder === "undefined") {
@@ -348,6 +349,50 @@ function getVisualDimensions(visual) {
 }
 
 const maskedVisualLayerCache = new WeakMap();
+const visualEffectsLayerCache = new WeakMap();
+
+function getVisualEffectsLayers(canvas) {
+  let layers = visualEffectsLayerCache.get(canvas);
+  if (!layers) {
+    layers = { visual: document.createElement("canvas"), mask: document.createElement("canvas") };
+    visualEffectsLayerCache.set(canvas, layers);
+  }
+  for (const layer of Object.values(layers)) {
+    if (layer.width !== canvas.width || layer.height !== canvas.height) {
+      layer.width = canvas.width;
+      layer.height = canvas.height;
+    }
+  }
+  return layers;
+}
+
+function drawVisualEffectsMask(context, mask, canvas) {
+  const geometry = getVisualMaskGeometry(mask, canvas);
+  const feather = getVisualMaskFeatherPixels(mask, canvas);
+  context.clearRect(0, 0, canvas.width, canvas.height);
+  context.save();
+  if (mask.inverted) {
+    context.fillStyle = "#fff";
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.globalCompositeOperation = "destination-out";
+  }
+  context.fillStyle = "#fff";
+  context.filter = feather ? `blur(${feather}px)` : "none";
+  context.beginPath();
+  if (mask.type === "circle") {
+    context.arc(geometry.centerX, geometry.centerY, geometry.radius, 0, Math.PI * 2);
+  } else {
+    context.roundRect(
+      geometry.centerX - geometry.width / 2,
+      geometry.centerY - geometry.height / 2,
+      geometry.width,
+      geometry.height,
+      geometry.cornerRadius,
+    );
+  }
+  context.fill();
+  context.restore();
+}
 
 function getMaskedVisualLayer(canvas) {
   let layer = maskedVisualLayerCache.get(canvas);
@@ -472,13 +517,59 @@ function drawPreviewFrame(context, visual, canvas, options) {
     stickerImage = null,
     transitionId = "none",
     vision = null,
+    visualEffects = null,
+    visualTime = 0,
   } = options;
 
   const { width, height } = canvas;
   context.clearRect(0, 0, width, height);
   context.fillStyle = "#090b0f";
   context.fillRect(0, 0, width, height);
-  const visualLayout = drawFittedVisual(context, visual, canvas, fitMode, filter, vision);
+  const transform = resolveVisualTransform(visualEffects?.keyframes, visualTime);
+  const mask = visualEffects?.mask ?? {};
+  const maskCenterX = (Number.isFinite(mask.centerX) ? mask.centerX : 50) / 100 * width;
+  const maskCenterY = (Number.isFinite(mask.centerY) ? mask.centerY : 50) / 100 * height;
+  const circleSize = (Number.isFinite(mask.size) ? mask.size : 72) / 100 * Math.min(width, height);
+  const maskWidth = mask.type === "circle" ? circleSize : (Number.isFinite(mask.width) ? mask.width : 80) / 100 * width;
+  const maskHeight = mask.type === "circle" ? circleSize : (Number.isFinite(mask.height) ? mask.height : 80) / 100 * height;
+  const usesAlphaMask = mask.type && mask.type !== "none" && (mask.inverted || Number(mask.feather) > 0);
+  let visualLayout;
+  if (usesAlphaMask) {
+    const layers = getVisualEffectsLayers(canvas);
+    const layerContext = layers.visual.getContext("2d");
+    const maskContext = layers.mask.getContext("2d");
+    layerContext.clearRect(0, 0, width, height);
+    layerContext.save();
+    layerContext.globalAlpha = transform.opacity;
+    layerContext.translate(width / 2 + (transform.x / 100) * width, height / 2 + (transform.y / 100) * height);
+    layerContext.rotate((transform.rotation * Math.PI) / 180);
+    layerContext.scale(transform.scale, transform.scale);
+    layerContext.translate(-width / 2, -height / 2);
+    visualLayout = drawFittedVisual(layerContext, visual, layers.visual, fitMode, filter, vision);
+    layerContext.restore();
+    drawVisualEffectsMask(maskContext, mask, layers.mask);
+    layerContext.save();
+    layerContext.globalCompositeOperation = "destination-in";
+    layerContext.drawImage(layers.mask, 0, 0);
+    layerContext.restore();
+    context.drawImage(layers.visual, 0, 0);
+  } else {
+    context.save();
+    if (mask.type === "circle") {
+      context.beginPath();
+      context.ellipse(maskCenterX, maskCenterY, maskWidth / 2, maskHeight / 2, 0, 0, Math.PI * 2);
+      context.clip();
+    } else if (["rectangle", "rounded"].includes(mask.type)) {
+      context.beginPath(); context.roundRect(maskCenterX - maskWidth / 2, maskCenterY - maskHeight / 2, maskWidth, maskHeight, mask.type === "rounded" ? Math.min(maskWidth, maskHeight) * (Number.isFinite(mask.cornerRadius) ? mask.cornerRadius : 12) / 100 : 0); context.clip();
+    }
+    context.globalAlpha = transform.opacity;
+    context.translate(width / 2 + (transform.x / 100) * width, height / 2 + (transform.y / 100) * height);
+    context.rotate((transform.rotation * Math.PI) / 180);
+    context.scale(transform.scale, transform.scale);
+    context.translate(-width / 2, -height / 2);
+    visualLayout = drawFittedVisual(context, visual, canvas, fitMode, filter, vision);
+    context.restore();
+  }
 
   if (captionsEnabled && subtitle) {
     const captionLayout = getCaptionTextLayout({
@@ -886,6 +977,8 @@ export async function exportBrowserVideo({
       stickerImage: exportSticker?.src ? stickerImageMap.get(exportSticker.src) : null,
       transitionId,
       vision: frameVision,
+      visualEffects: visualItem.segment,
+      visualTime: localTime,
     });
 
     if (elapsed === totalDuration || performance.now() - lastProgressUpdate > 180) {

--- a/src/lib/visualEffects.js
+++ b/src/lib/visualEffects.js
@@ -1,0 +1,161 @@
+const DEFAULT_TRANSFORM = Object.freeze({ x: 0, y: 0, scale: 1, rotation: 0, opacity: 1 });
+export const VISUAL_TRANSFORM_KEYS = Object.freeze(["scale", "x", "y", "rotation", "opacity"]);
+const KEYFRAME_TIME_TOLERANCE = 0.04;
+
+function normalizeVisualProperty(key, value) {
+  if (key === "scale") return Math.max(0.1, Number(value) || 1);
+  if (key === "opacity") return Math.max(0, Math.min(1, Number.isFinite(Number(value)) ? Number(value) : 1));
+  return Number(value) || 0;
+}
+
+export function normalizeVisualTransform(value = {}) {
+  return {
+    x: Number(value.x) || 0,
+    y: Number(value.y) || 0,
+    scale: Math.max(0.1, Number(value.scale) || 1),
+    rotation: Number(value.rotation) || 0,
+    opacity: Math.max(0, Math.min(1, Number.isFinite(Number(value.opacity)) ? Number(value.opacity) : 1)),
+  };
+}
+
+export function normalizeVisualKeyframes(keyframes = []) {
+  return keyframes
+    .filter((frame) => frame && Number.isFinite(Number(frame.time)))
+    .map((frame) => ({ ...frame, time: Math.max(0, Number(frame.time)) }))
+    .sort((a, b) => a.time - b.time)
+    .reduce((frames, frame) => {
+      const previous = frames.at(-1);
+      if (!previous || Math.abs(previous.time - frame.time) > KEYFRAME_TIME_TOLERANCE) {
+        frames.push(frame);
+        return frames;
+      }
+      frames[frames.length - 1] = { ...previous, ...frame };
+      return frames;
+    }, []);
+}
+
+export function resolveVisualTransform(keyframes = [], time = 0) {
+  const safeTime = Math.max(0, Number(time) || 0);
+  const normalizedKeyframes = normalizeVisualKeyframes(keyframes);
+  return Object.fromEntries(VISUAL_TRANSFORM_KEYS.map((key) => {
+    const frames = normalizedKeyframes
+      .filter((frame) => Number.isFinite(Number(frame[key])))
+      .map((frame) => ({ time: Math.max(0, Number(frame.time) || 0), value: normalizeVisualProperty(key, frame[key]) }))
+      .sort((a, b) => a.time - b.time);
+    if (!frames.length) return [key, DEFAULT_TRANSFORM[key]];
+    // A keyframe starts controlling its property at its own timestamp. Before
+    // the first keyframe the clip must retain its unmodified default value.
+    if (safeTime < frames[0].time) return [key, DEFAULT_TRANSFORM[key]];
+    if (safeTime === frames[0].time) return [key, frames[0].value];
+    if (safeTime >= frames.at(-1).time) return [key, frames.at(-1).value];
+    const rightIndex = frames.findIndex((frame) => frame.time >= safeTime);
+    const left = frames[rightIndex - 1];
+    const right = frames[rightIndex];
+    const progress = (safeTime - left.time) / Math.max(0.0001, right.time - left.time);
+    return [key, left.value + (right.value - left.value) * progress];
+  }));
+}
+
+export function upsertVisualKeyframe(keyframes = [], time, transform) {
+  const safeTime = Math.max(0, Number(time) || 0);
+  const normalized = normalizeVisualKeyframes(keyframes);
+  const matching = normalized.filter((frame) => Math.abs(frame.time - safeTime) <= KEYFRAME_TIME_TOLERANCE);
+  const next = normalized.filter((frame) => Math.abs(frame.time - safeTime) > KEYFRAME_TIME_TOLERANCE);
+  next.push({ ...Object.assign({}, ...matching), time: safeTime, ...normalizeVisualTransform(transform) });
+  return normalizeVisualKeyframes(next);
+}
+
+export function hasVisualPropertyKeyframe(keyframes = [], time, key) {
+  return normalizeVisualKeyframes(keyframes).some((frame) => Math.abs(frame.time - (Number(time) || 0)) <= KEYFRAME_TIME_TOLERANCE && Number.isFinite(Number(frame[key])));
+}
+
+export function upsertVisualPropertyKeyframe(keyframes = [], time, key, value) {
+  if (!VISUAL_TRANSFORM_KEYS.includes(key)) return keyframes;
+  const safeTime = Math.max(0, Number(time) || 0);
+  const normalized = normalizeVisualKeyframes(keyframes);
+  const matching = normalized.filter((frame) => Math.abs(frame.time - safeTime) <= KEYFRAME_TIME_TOLERANCE);
+  const next = normalized.filter((frame) => Math.abs(frame.time - safeTime) > KEYFRAME_TIME_TOLERANCE);
+  next.push({ ...Object.assign({}, ...matching), time: safeTime, [key]: normalizeVisualProperty(key, value) });
+  return normalizeVisualKeyframes(next);
+}
+
+export function removeVisualPropertyKeyframe(keyframes = [], time, key) {
+  return normalizeVisualKeyframes(keyframes).flatMap((frame) => {
+    if (Math.abs(frame.time - (Number(time) || 0)) > KEYFRAME_TIME_TOLERANCE || !(key in frame)) return [frame];
+    const { [key]: _removed, ...rest } = frame;
+    return VISUAL_TRANSFORM_KEYS.some((property) => property in rest) ? [rest] : [];
+  });
+}
+
+export function getVisualMaskCss(mask = {}) {
+  const feather = Math.max(0, Math.min(40, Number(mask.feather) || 0));
+  const edge = Math.max(0, 50 - feather);
+  if (mask.type === "circle") return `radial-gradient(circle at 50% 50%, #000 ${edge}%, transparent 50%)`;
+  if (mask.type === "rounded") return "linear-gradient(#000, #000)";
+  return "";
+}
+
+export function getVisualMaskInsets(mask = {}) {
+  const centerX = Number.isFinite(mask.centerX) ? mask.centerX : 50;
+  const centerY = Number.isFinite(mask.centerY) ? mask.centerY : 50;
+  const width = Number.isFinite(mask.width) ? mask.width : 80;
+  const height = Number.isFinite(mask.height) ? mask.height : 80;
+  return {
+    top: Math.max(0, centerY - height / 2),
+    right: Math.max(0, 100 - (centerX + width / 2)),
+    bottom: Math.max(0, 100 - (centerY + height / 2)),
+    left: Math.max(0, centerX - width / 2),
+  };
+}
+
+export function getCircleMaskCss(mask = {}, frame = {}) {
+  if (mask.type !== "circle") return "";
+  const feather = Math.max(0, Math.min(40, Number(mask.feather) || 0));
+  if (!feather && !mask.inverted) return "";
+  const width = Math.max(1, Number(frame.width) || 1);
+  const height = Math.max(1, Number(frame.height) || 1);
+  const radius = ((Number.isFinite(mask.size) ? mask.size : 72) / 200) * Math.min(width, height);
+  const centerX = Number.isFinite(mask.centerX) ? mask.centerX : 50;
+  const centerY = Number.isFinite(mask.centerY) ? mask.centerY : 50;
+  const innerStop = Math.max(0, 100 - feather);
+  return `radial-gradient(circle ${radius}px at ${centerX}% ${centerY}%, ${mask.inverted ? "transparent" : "#000"} ${innerStop}%, ${mask.inverted ? "#000" : "transparent"} 100%)`;
+}
+
+export function getVisualMaskGeometry(mask = {}, frame = {}) {
+  const frameWidth = Math.max(1, Number(frame.width) || 1);
+  const frameHeight = Math.max(1, Number(frame.height) || 1);
+  const centerX = (Number.isFinite(mask.centerX) ? mask.centerX : 50) / 100 * frameWidth;
+  const centerY = (Number.isFinite(mask.centerY) ? mask.centerY : 50) / 100 * frameHeight;
+  if (mask.type === "circle") {
+    const diameter = (Number.isFinite(mask.size) ? mask.size : 72) / 100 * Math.min(frameWidth, frameHeight);
+    return { centerX, centerY, width: diameter, height: diameter, radius: diameter / 2, cornerRadius: diameter / 2 };
+  }
+  const width = (Number.isFinite(mask.width) ? mask.width : 80) / 100 * frameWidth;
+  const height = (Number.isFinite(mask.height) ? mask.height : 80) / 100 * frameHeight;
+  const cornerRadius = mask.type === "rounded"
+    ? Math.min(width, height) * (Number.isFinite(mask.cornerRadius) ? mask.cornerRadius : 12) / 100
+    : 0;
+  return { centerX, centerY, width, height, radius: 0, cornerRadius };
+}
+
+export function getVisualMaskFeatherPixels(mask = {}, frame = {}) {
+  if (!mask.type || mask.type === "none") return 0;
+  const geometry = getVisualMaskGeometry(mask, frame);
+  return Math.max(0, Math.min(40, Number(mask.feather) || 0)) / 100 * Math.min(geometry.width, geometry.height) * 0.25;
+}
+
+export function getVisualMaskSvgDataUrl(mask = {}, frame = {}) {
+  if (!mask.type || mask.type === "none") return "";
+  const width = Math.max(1, Math.round(Number(frame.width) || 1));
+  const height = Math.max(1, Math.round(Number(frame.height) || 1));
+  const geometry = getVisualMaskGeometry(mask, { width, height });
+  const feather = getVisualMaskFeatherPixels(mask, { width, height });
+  if (!feather && !mask.inverted) return "";
+  const x = geometry.centerX - geometry.width / 2;
+  const y = geometry.centerY - geometry.height / 2;
+  const shape = mask.type === "circle"
+    ? `<circle cx="${geometry.centerX}" cy="${geometry.centerY}" r="${geometry.radius}" fill="${mask.inverted ? "black" : "white"}"${feather ? ' filter="url(#blur)"' : ""}/>`
+    : `<rect x="${x}" y="${y}" width="${geometry.width}" height="${geometry.height}" rx="${geometry.cornerRadius}" fill="${mask.inverted ? "black" : "white"}"${feather ? ' filter="url(#blur)"' : ""}/>`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><defs>${feather ? `<filter id="blur" x="-50%" y="-50%" width="200%" height="200%"><feGaussianBlur stdDeviation="${feather}"/></filter>` : ""}<mask id="mask" maskUnits="userSpaceOnUse" x="0" y="0" width="${width}" height="${height}"><rect width="${width}" height="${height}" fill="${mask.inverted ? "white" : "black"}"/>${shape}</mask></defs><rect width="${width}" height="${height}" fill="white" mask="url(#mask)"/></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}

--- a/src/lib/visualEffects.test.js
+++ b/src/lib/visualEffects.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { getCircleMaskCss, getVisualMaskFeatherPixels, getVisualMaskInsets, getVisualMaskSvgDataUrl, hasVisualPropertyKeyframe, normalizeVisualKeyframes, removeVisualPropertyKeyframe, resolveVisualTransform, upsertVisualKeyframe, upsertVisualPropertyKeyframe } from "./visualEffects.js";
+
+describe("visual effects", () => {
+  it("interpolates visual keyframes", () => {
+    expect(resolveVisualTransform([{ time: 0, x: 0, scale: 1 }, { time: 2, x: 40, scale: 2 }], 1))
+      .toMatchObject({ x: 20, scale: 1.5 });
+  });
+
+  it("keeps defaults before the first keyframe, interpolates between frames, and holds the last frame", () => {
+    const frames = [{ time: 1, x: 20, scale: 1.2 }, { time: 3, x: 60, scale: 1.6 }];
+    expect(resolveVisualTransform(frames, 0.5)).toMatchObject({ x: 0, scale: 1 });
+    expect(resolveVisualTransform(frames, 1)).toMatchObject({ x: 20, scale: 1.2 });
+    expect(resolveVisualTransform(frames, 2)).toMatchObject({ x: 40, scale: 1.4 });
+    expect(resolveVisualTransform(frames, 3.5)).toMatchObject({ x: 60, scale: 1.6 });
+  });
+
+  it("replaces a keyframe at the same time", () => {
+    expect(upsertVisualKeyframe([{ time: 1, x: 2 }], 1.02, { x: 8 })).toHaveLength(1);
+  });
+
+  it("coalesces duplicate sparse frames before resolving them", () => {
+    expect(normalizeVisualKeyframes([{ time: 1, x: 20 }, { time: 1.02, opacity: 0.5 }]))
+      .toEqual([{ time: 1.02, x: 20, opacity: 0.5 }]);
+  });
+
+  it("matches the editor workflow before, between, and after two edited frames", () => {
+    let frames = upsertVisualKeyframe([], 1, resolveVisualTransform([], 1));
+    frames = upsertVisualPropertyKeyframe(frames, 1, "x", 20);
+    frames = upsertVisualKeyframe(frames, 3, resolveVisualTransform(frames, 3));
+    frames = upsertVisualPropertyKeyframe(frames, 3, "x", 60);
+    expect(resolveVisualTransform(frames, 0.5).x).toBe(0);
+    expect(resolveVisualTransform(frames, 1).x).toBe(20);
+    expect(resolveVisualTransform(frames, 2).x).toBe(40);
+    expect(resolveVisualTransform(frames, 4).x).toBe(60);
+  });
+
+  it("stores and interpolates complete transforms using only add-all frames", () => {
+    let frames = upsertVisualKeyframe([], 1, { x: 20, y: -10, scale: 1.2, rotation: 5, opacity: 0.8 });
+    frames = upsertVisualKeyframe(frames, 3, { x: 60, y: 30, scale: 1.6, rotation: 25, opacity: 0.4 });
+    expect(frames).toEqual([
+      { time: 1, x: 20, y: -10, scale: 1.2, rotation: 5, opacity: 0.8 },
+      { time: 3, x: 60, y: 30, scale: 1.6, rotation: 25, opacity: 0.4 },
+    ]);
+    expect(resolveVisualTransform(frames, 0.5)).toEqual({ scale: 1, x: 0, y: 0, rotation: 0, opacity: 1 });
+    const midpoint = resolveVisualTransform(frames, 2);
+    expect(midpoint).toMatchObject({ scale: 1.4, x: 40, y: 10, rotation: 15 });
+    expect(midpoint.opacity).toBeCloseTo(0.6);
+    expect(resolveVisualTransform(frames, 4)).toEqual({ scale: 1.6, x: 60, y: 30, rotation: 25, opacity: 0.4 });
+  });
+
+  it("interpolates sparse property keyframes independently", () => {
+    expect(resolveVisualTransform([{ time: 0, x: 0 }, { time: 1, opacity: 0.5 }, { time: 2, x: 40 }], 1))
+      .toMatchObject({ x: 20, opacity: 0.5, scale: 1, y: 0 });
+  });
+
+  it("adds and removes one property without touching others", () => {
+    const added = upsertVisualPropertyKeyframe([{ time: 1, x: 12 }], 1, "opacity", 0.4);
+    expect(added).toEqual([{ time: 1, x: 12, opacity: 0.4 }]);
+    expect(hasVisualPropertyKeyframe(added, 1, "opacity")).toBe(true);
+    expect(removeVisualPropertyKeyframe(added, 1, "opacity")).toEqual([{ time: 1, x: 12 }]);
+  });
+
+  it("maps a moved mask to CSS inset sides without mirroring", () => {
+    expect(getVisualMaskInsets({ centerX: 30, centerY: 60, width: 40, height: 20 }))
+      .toEqual({ top: 50, right: 50, bottom: 30, left: 10 });
+  });
+
+  it("does not stack a gradient mask on a zero-feather circle", () => {
+    expect(getCircleMaskCss({ type: "circle", size: 72, feather: 0 }, { width: 1600, height: 900 })).toBe("");
+  });
+
+  it("uses the full pixel radius for a feathered circle", () => {
+    expect(getCircleMaskCss({ type: "circle", size: 72, feather: 10 }, { width: 1600, height: 900 }))
+      .toBe("radial-gradient(circle 324px at 50% 50%, #000 90%, transparent 100%)");
+  });
+
+  it("builds an alpha hole for an inverted rectangle", () => {
+    const svg = decodeURIComponent(getVisualMaskSvgDataUrl({ type: "rectangle", inverted: true }, { width: 1000, height: 500 }).split(",")[1]);
+    expect(svg).toContain('<rect width="1000" height="500" fill="white"/>');
+    expect(svg).toContain('width="800" height="400" rx="0" fill="black"');
+  });
+
+  it("adds blur to feathered rectangle and rounded masks", () => {
+    for (const type of ["rectangle", "rounded"]) {
+      const svg = decodeURIComponent(getVisualMaskSvgDataUrl({ type, feather: 20 }, { width: 1000, height: 500 }).split(",")[1]);
+      expect(svg).toContain("<feGaussianBlur");
+      expect(svg).toContain('filter="url(#blur)"');
+    }
+  });
+
+  it("scales feather width from the active shape rather than the full frame", () => {
+    expect(getVisualMaskFeatherPixels({ type: "rectangle", width: 80, height: 40, feather: 20 }, { width: 1000, height: 500 })).toBe(10);
+  });
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -2062,6 +2062,42 @@ button:disabled {
   gap: 10px;
 }
 
+.visual-effects-panel { gap: 12px; }
+.visual-effects-panel > .tool-panel { padding: 0; }
+.visual-effects-panel > .tool-panel > h2 { font-size: 13px; color: #9ba9b2; }
+.visual-editor-card { display: grid; gap: 12px; padding: 13px; border: 1px solid rgba(255,255,255,.08); border-radius: 9px; background: rgba(255,255,255,.035); }
+.visual-editor-heading { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.visual-editor-heading span { display: flex; align-items: center; gap: 7px; font-weight: 760; }
+.visual-editor-heading svg { color: #35ead9; }
+.visual-editor-heading em { color: #7f8d97; font-size: 11px; font-style: normal; }
+.mask-choice-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 6px; }
+.mask-choice-grid button { min-width: 0; padding: 8px 3px; border: 1px solid rgba(255,255,255,.09); border-radius: 6px; color: #aebbc3; background: rgba(255,255,255,.035); font-size: 11px; cursor: pointer; }
+.mask-choice-grid button.is-active { border-color: #35ead9; color: #eafffd; background: rgba(53,234,217,.12); }
+.mask-empty-hint { margin: 2px 0 0; color: #7f8d97; font-size: 11px; line-height: 1.5; }
+.visual-add-all-keyframes { display: flex; align-items: center; justify-content: center; gap: 7px; min-height: 34px; color: #8debe2; }
+.visual-keyframe-times { display: flex; gap: 5px; overflow-x: auto; padding: 1px 0 3px; scrollbar-width: thin; }
+.visual-keyframe-times button { flex: 0 0 auto; border: 1px solid rgba(255,255,255,.08); border-radius: 999px; padding: 3px 7px; color: #829099; background: rgba(255,255,255,.03); font-size: 10px; font-variant-numeric: tabular-nums; cursor: pointer; }
+.visual-keyframe-times button:hover { border-color: rgba(53,234,217,.34); color: #c5f9f4; }
+.visual-keyframe-times button.is-current { border-color: rgba(53,234,217,.55); color: #9af4eb; background: rgba(53,234,217,.12); }
+.visual-property-value { display: flex; align-items: center; gap: 8px; }
+.visual-number-field { display: flex; align-items: center; justify-content: flex-end; width: 82px; height: 24px; overflow: hidden; border: 1px solid rgba(255,255,255,.1); border-radius: 6px; background: rgba(5,10,14,.38); }
+.visual-number-field:focus-within { border-color: rgba(53,234,217,.58); box-shadow: 0 0 0 1px rgba(53,234,217,.08); }
+.visual-number-field input { box-sizing: border-box; width: 58px; height: 100%; appearance: textfield; border: 0; padding: 0 4px 0 7px; color: #d9e6eb; background: transparent; font: inherit; font-size: 11px; text-align: right; outline: 0; font-variant-numeric: tabular-nums; }
+.visual-number-field input::-webkit-inner-spin-button,
+.visual-number-field input::-webkit-outer-spin-button { margin: 0; -webkit-appearance: none; appearance: none; }
+.visual-number-field i { flex: 0 0 auto; width: 17px; padding-right: 6px; color: #77858e; font-size: 10px; font-style: normal; text-align: left; }
+.visual-property-value > button { display: grid; place-items: center; width: 24px; height: 24px; border: 1px solid rgba(255,255,255,.1); border-radius: 6px; padding: 0; color: #81909a; background: rgba(255,255,255,.035); cursor: pointer; }
+.visual-property-value > button:hover { border-color: rgba(53,234,217,.4); color: #8debe2; }
+.visual-property-value > button.is-active { border-color: rgba(53,234,217,.62); color: #35ead9; background: rgba(53,234,217,.12); box-shadow: 0 0 0 1px rgba(53,234,217,.06); }
+.preview-frame > img, .preview-frame > video { transform-origin: center; }
+.visual-mask-editor { position: absolute; z-index: 8; box-sizing: border-box; border: 1.5px solid #35ead9; border-radius: 2px; background: rgba(53,234,217,.035); box-shadow: 0 0 0 1px rgba(3,12,15,.7), 0 0 18px rgba(53,234,217,.13); cursor: move; touch-action: none; }
+.visual-mask-editor.is-circle { border-radius: 50%; }
+.visual-mask-editor.is-rounded { border-radius: 12%; }
+.visual-mask-editor > span { position: absolute; top: -25px; left: 0; padding: 3px 7px; border-radius: 4px; color: #061515; background: #35ead9; font-size: 10px; font-weight: 800; }
+.visual-mask-editor > button { position: absolute; right: -7px; bottom: -7px; width: 14px; height: 14px; border: 2px solid #071014; border-radius: 50%; padding: 0; background: #35ead9; cursor: nwse-resize; }
+.visual-effects-panel.is-context-mode { padding: 0; }
+.voice-panel.is-visual-context .voice-tab-body { padding-top: 4px; }
+
 .visual-choice-card {
   position: relative;
   min-width: 0;
@@ -2281,8 +2317,22 @@ button:disabled {
   background-size: 14px 14px;
 }
 
-.preview-frame.has-background-removed > img {
+.preview-frame.has-background-removed > .visual-media-layer > img {
   background: transparent;
+}
+
+.visual-media-layer {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+}
+
+.visual-media-layer > img,
+.visual-media-layer > video {
+  grid-area: 1 / 1;
 }
 
 .preview-frame img,
@@ -2483,7 +2533,7 @@ button:disabled {
 }
 
 .scrubber,
-.slider-field input {
+.slider-field input[type="range"] {
   width: 100%;
   height: 4px;
   accent-color: #35ead9;


### PR DESCRIPTION
## What changed

- Move clip-scoped Visuals controls into the right context panel and remove the redundant Effects rail entry.
- Add grouped and property-level transform keyframes with correct default-before-first, linear interpolation, and hold-after-last behavior.
- Make keyframe timestamp chips clickable playhead shortcuts and fix clipped numeric property fields.
- Add rectangle, rounded-rectangle, and circular masks with direct preview editing, shape-specific controls, feathering, inversion, and matching export rendering.
- Add localized Visuals copy and regression coverage, including a real uploaded MP4 Add all keyframes flow.

## Why

The previous prototype could record keyframes but did not reliably resolve duplicate or sparse frames, showed inert timestamp pills, clipped numeric values through an overly broad slider CSS rule, and did not keep preview and export mask behavior aligned.

## Validation

- `npm test` — 40 tests passed
- `npm run typecheck`
- `npm run build`
- Real Chrome E2E with `ai-voiceover-16x9 (5).mp4` (H.264/AAC, 1280×720, 10.021s) — passed
