### PR TITLE
Add auto edit and polish timeline interactions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import { useVideoExport } from "./hooks/useVideoExport.js";
 import { useVoiceRecorder } from "./hooks/useVoiceRecorder.js";
 import { useVoiceGeneration } from "./hooks/useVoiceGeneration.js";
 import { useAutoCaptions } from "./hooks/useAutoCaptions.js";
+import { useAutoEdit } from "./hooks/useAutoEdit.js";
 import { useSourceAudioExtraction } from "./hooks/useSourceAudioExtraction.js";
 import { useVocalSeparation } from "./hooks/useVocalSeparation.js";
 import { useAvatarGeneration } from "./hooks/useAvatarGeneration.js";
@@ -76,6 +77,7 @@ export function App() {
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [exportSettings, setExportSettings] = useState({ resolution: "1080", frameRate: 30, codec: "h264", quality: "high" });
   const [captionVoiceFocusRequest, setCaptionVoiceFocusRequest] = useState(0);
+  const [selectedSourceAudioSegmentId, setSelectedSourceAudioSegmentId] = useState("");
   const timelineImportRestoreRef = useRef(false);
   const [introClosing, setIntroClosing] = useState(false);
   const {
@@ -349,6 +351,10 @@ export function App() {
     setScript, setSelectedSegmentId, setSelectedTrack,
     setVisionRecords, trackLocks,
   });
+  const autoEdit = useAutoEdit({
+    language: activeLanguage, visualSegments, commitCaptionSegments, setCaptionsEnabled,
+    setSelectedSegmentId, setSelectedTrack, notify, t,
+  });
   const {
     clearAudioTrack, clearMusicTrack, clearSourceAudioTrack, commitAudio,
     replaceAudio, replaceMusic, replaceSourceAudio,
@@ -475,7 +481,8 @@ export function App() {
     selectedSegmentIndex, selectedStickerSegmentId, selectedTrack,
     selectedVisualSegmentId, selectedVisualSegmentIndex, setAudioSegments,
     setCaptionSegments, setSelectedAudioSegmentId, setUserAssets, sourceAudioBlob,
-    sourceAudioName, stickerSegments, t, trackLocks, visualSegments, visualType,
+    sourceAudioLinked, sourceAudioName, selectedSourceAudioSegmentId,
+    setSelectedSourceAudioSegmentId, stickerSegments, t, trackLocks, visualSegments, visualType,
   });
 
   useEditorLifecycle({
@@ -840,6 +847,7 @@ export function App() {
           automaticCaptionProgress={status === "captioning" ? progress : 0}
           avatarPanelOpen={avatarPanelOpen}
           smartMode={smartMode}
+          autoEdit={autoEdit}
           uiLanguage={activeLanguage}
           visionAnalysis={previewVisionAnalysis}
           visionOptions={previewVisionOptions}
@@ -949,6 +957,8 @@ export function App() {
         sourceAudioClipPercent={sourceAudioClipPercent}
         sourceAudioStartPercent={sourceAudioStartPercent}
         sourceAudioDuration={sourceAudioDuration}
+        selectedSourceAudioSegmentId={selectedSourceAudioSegmentId}
+        setSelectedSourceAudioSegmentId={setSelectedSourceAudioSegmentId}
         audioBlob={audioBlob}
         peaks={peaks}
         audioClipPercent={audioClipPercent}

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -118,6 +118,7 @@ function getImageTimelineThumbnailCount({ duration, timelineDuration, contentWid
 
 export function Timeline({
   t,
+  trOption,
   undo,
   redo,
   handleDeleteTrack,
@@ -190,6 +191,8 @@ export function Timeline({
   sourceAudioClipPercent,
   sourceAudioStartPercent,
   sourceAudioDuration,
+  selectedSourceAudioSegmentId,
+  setSelectedSourceAudioSegmentId,
   audioBlob,
   peaks,
   audioClipPercent,
@@ -207,6 +210,16 @@ export function Timeline({
   startMusicMove,
 }) {
   const [transitionEditor, setTransitionEditor] = useState(null);
+  const [musicClipSelected, setMusicClipSelected] = useState(false);
+
+  const clearClipSelections = (except = "") => {
+    if (except !== "visual") setSelectedVisualSegmentId("");
+    if (except !== "sticker") setSelectedStickerSegmentId("");
+    if (except !== "caption") setSelectedSegmentId("");
+    if (except !== "voice") setSelectedAudioSegmentId("");
+    if (except !== "source") setSelectedSourceAudioSegmentId("");
+    if (except !== "music") setMusicClipSelected(false);
+  };
 
   const updateJunctionTransition = (index, patch) => {
     setVisualSegments((items) => items.map((item, itemIndex) => itemIndex === index
@@ -260,10 +273,14 @@ export function Timeline({
   };
   const selectContextTarget = (track, segmentId = "") => {
     openTrackPanel(track);
+    const selectionType = { image: "visual", sticker: "sticker", caption: "caption", audio: "voice", source: "source", music: "music" }[track];
+    clearClipSelections(selectionType);
     if (track === "image" && segmentId) setSelectedVisualSegmentId(segmentId);
     if (track === "sticker" && segmentId) setSelectedStickerSegmentId(segmentId);
     if (track === "caption" && segmentId) setSelectedSegmentId(segmentId);
     if (track === "audio" && segmentId) setSelectedAudioSegmentId(segmentId);
+    if (track === "source" && segmentId) setSelectedSourceAudioSegmentId(segmentId);
+    if (track === "music" && segmentId) setMusicClipSelected(true);
   };
   const showTrackContextMenu = (event, track, segmentId = "") => {
     event.preventDefault(); event.stopPropagation();
@@ -626,6 +643,7 @@ export function Timeline({
                     }
                     setSelectedTrack("sticker");
                     setActiveTool("stickers");
+                    clearClipSelections("sticker");
                     setSelectedStickerSegmentId(segment.id);
                     seekTo(segment.start || 0);
                   }}
@@ -882,12 +900,14 @@ export function Timeline({
                             return;
                           }
                           setSelectedTrack("image");
+                          clearClipSelections("visual");
                           setSelectedVisualSegmentId(segment.id);
                         }}
                         onKeyDown={(event) => {
                           if (event.key === "Enter" || event.key === " ") {
                             event.preventDefault();
                             setSelectedTrack("image");
+                            clearClipSelections("visual");
                             setSelectedVisualSegmentId(segment.id);
                           }
                         }}
@@ -953,7 +973,7 @@ export function Timeline({
                     className={`visual-junction ${transition.id !== "none" ? "has-transition" : ""}`}
                     key={`junction-${segment.id}`}
                     type="button"
-                    aria-label={`转场：${TRANSITIONS.find((item) => item.id === transition.id)?.name || "无转场"}`}
+                    aria-label={`${t("transition")}: ${trOption(TRANSITIONS.find((item) => item.id === transition.id)?.name || "无转场")}`}
                     title="设置转场"
                     style={{ left: `${((range?.end || 0) / Math.max(0.01, timelineDuration)) * 100}%` }}
                     onPointerDown={(event) => event.stopPropagation()}
@@ -1028,6 +1048,7 @@ export function Timeline({
                           }
                           setSelectedTrack("caption");
                           setActiveTool("caption");
+                          clearClipSelections("caption");
                           setSelectedSegmentId(segment.id);
                           seekTo(segmentRange?.start ?? getSegmentStartTime(displayedCaptionSegments, index, captionTargetDuration));
                         }}
@@ -1055,7 +1076,10 @@ export function Timeline({
                 assetDropTargetTrack === "source" ? "is-drop-target" : ""
               } ${assetDropPulseTrack === "source" ? "is-drop-landing" : ""}`}
               type="button"
-              onClick={() => setSelectedTrack("source")}
+              onClick={() => {
+                setSelectedTrack("source");
+                setSelectedSourceAudioSegmentId("");
+              }}
               onDragOver={(event) => handleTrackAssetDragOver(event, "source")}
               onDragLeave={(event) => handleTrackAssetDragLeave(event, "source")}
               onDrop={(event) => handleTrackAssetDrop(event, "source")}
@@ -1068,7 +1092,7 @@ export function Timeline({
               {renderAssetDropSlot("source")}
               {sourceAudioBlob && sourceAudioLinked && linkedSourceAudioSegments.length ? linkedSourceAudioSegments.map((segment) => (
                 <div
-                  className="audio-clip is-source is-linked"
+                  className={`audio-clip is-source is-linked ${selectedSourceAudioSegmentId === segment.id ? "is-selected" : ""}`}
                   key={segment.id}
                   style={{
                     width: `${timelineDuration > 0 ? Math.max(0.01, Math.min(100, (segment.duration / timelineDuration) * 100)) : 0}%`,
@@ -1076,19 +1100,31 @@ export function Timeline({
                   }}
                   onContextMenu={(event) => showTrackContextMenu(event, "source", segment.id)}
                   onPointerDown={startSourceAudioMove}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setSelectedTrack("source");
+                    clearClipSelections("source");
+                    setSelectedSourceAudioSegmentId(segment.id);
+                  }}
                 >
                   <WaveformStrip peaks={sliceSourceAudioPeaks(sourceAudioPeaks, segment, sourceAudioDuration)} active />
                   <span className="audio-clip-duration">{formatTime(segment.duration)}</span>
                 </div>
               )) : sourceAudioBlob ? (
                 <div
-                  className="audio-clip is-source"
+                  className={`audio-clip is-source ${selectedSourceAudioSegmentId === "source-audio" ? "is-selected" : ""}`}
                   style={{
                     width: `${sourceAudioClipPercent}%`,
                     marginLeft: `${sourceAudioStartPercent}%`,
                   }}
                   onContextMenu={(event) => showTrackContextMenu(event, "source", "source-audio")}
                   onPointerDown={startSourceAudioMove}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setSelectedTrack("source");
+                    clearClipSelections("source");
+                    setSelectedSourceAudioSegmentId("source-audio");
+                  }}
                 >
                   <WaveformStrip peaks={sourceAudioPeaks} active />
                   <span className="audio-clip-duration">{formatTime(sourceAudioDuration)}</span>
@@ -1128,6 +1164,7 @@ export function Timeline({
                         onClick={(event) => {
                           event.stopPropagation();
                           setSelectedTrack("audio");
+                          clearClipSelections("voice");
                           setSelectedAudioSegmentId(segment.id);
                           seekTo(segment.start);
                         }}
@@ -1146,7 +1183,10 @@ export function Timeline({
                 assetDropTargetTrack === "music" ? "is-drop-target" : ""
               } ${assetDropPulseTrack === "music" ? "is-drop-landing" : ""}`}
               type="button"
-              onClick={() => setSelectedTrack("music")}
+              onClick={() => {
+                setSelectedTrack("music");
+                setMusicClipSelected(false);
+              }}
               onDragOver={(event) => handleTrackAssetDragOver(event, "music")}
               onDragLeave={(event) => handleTrackAssetDragLeave(event, "music")}
               onDrop={(event) => handleTrackAssetDrop(event, "music")}
@@ -1158,7 +1198,7 @@ export function Timeline({
                 ) : null}
               {renderAssetDropSlot("music")}
                 {musicBlob ? (
-                <div className="audio-clip is-music" style={{ width: `${musicClipPercent}%`, left: `${musicStartPercent}%` }} onPointerDown={startMusicMove} onContextMenu={(event) => showTrackContextMenu(event, "music", "music-audio")}>
+                <div className={`audio-clip is-music ${musicClipSelected ? "is-selected" : ""}`} style={{ width: `${musicClipPercent}%`, left: `${musicStartPercent}%` }} onPointerDown={startMusicMove} onContextMenu={(event) => showTrackContextMenu(event, "music", "music-audio")} onClick={(event) => { event.stopPropagation(); setSelectedTrack("music"); clearClipSelections("music"); setMusicClipSelected(true); }}>
                   <WaveformStrip peaks={musicPeaks} active />
                   <span className="audio-clip-duration">{formatTime(musicDuration)}</span>
                 </div>
@@ -1222,17 +1262,17 @@ export function Timeline({
         const transition = segment?.transition || { id: "none", duration: 0.5 };
         const maxDuration = Math.max(0.1, Math.min(2, (segment?.duration || 0.5) / 2, (displayedVisualSegments[transitionEditor.index + 1]?.duration || 0.5) / 2));
         return (
-          <div className="transition-popover" role="dialog" aria-label="转场设置" style={{ left: transitionEditor.x, top: transitionEditor.y }} onPointerDown={(event) => event.stopPropagation()}>
-            <div className="transition-popover-head"><strong>转场</strong><button type="button" onClick={() => setTransitionEditor(null)} aria-label="关闭">×</button></div>
+          <div className="transition-popover" role="dialog" aria-label={t("transitionSettings")} style={{ left: transitionEditor.x, top: transitionEditor.y }} onPointerDown={(event) => event.stopPropagation()}>
+            <div className="transition-popover-head"><strong>{t("transition")}</strong><button type="button" onClick={() => setTransitionEditor(null)} aria-label={t("close")}>×</button></div>
             <div className="transition-presets">
               {TRANSITIONS.map((option) => (
                 <button type="button" className={transition.id === option.id ? "is-selected" : ""} key={option.id} onClick={() => updateJunctionTransition(transitionEditor.index, { id: option.id })}>
-                  <i className={`transition-preview preview-${option.id}`} /><span>{option.name}</span>
+                  <i className={`transition-preview preview-${option.id}`} /><span>{trOption(option.name, option)}</span>
                 </button>
               ))}
             </div>
             <label className="transition-duration-control">
-              <span><b>时长</b><em>{Math.min(maxDuration, transition.duration || 0.5).toFixed(1)}s</em></span>
+              <span><b>{t("duration")}</b><em>{Math.min(maxDuration, transition.duration || 0.5).toFixed(1)}{t("secondsShort")}</em></span>
               <input type="range" min="0.1" max={maxDuration} step="0.1" value={Math.min(maxDuration, transition.duration || 0.5)} disabled={transition.id === "none"} onChange={(event) => updateJunctionTransition(transitionEditor.index, { duration: Number(event.target.value) })} />
             </label>
           </div>

--- a/src/components/VoicePanel.jsx
+++ b/src/components/VoicePanel.jsx
@@ -19,6 +19,26 @@ import { getCaptionVoiceSegment } from "../lib/captionVoice.js";
 import { normalizeVisualKeyframes } from "../lib/visualEffects.js";
 import { HistoryPanel, MyVoicesPanel, SmartVisionPanel, VisualEffectsPanel, VoiceSynthesisPanel } from "./panels.jsx";
 
+function AutoEditPanel({ t, hasVisual, language, autoEdit }) {
+  const availability = autoEdit?.support?.availability || "unknown";
+  const languageFallback = autoEdit?.support?.language && autoEdit.support.language !== language;
+  const ready = availability === "available" || availability === "downloadable" || availability === "downloading";
+  return (
+    <div className="auto-edit-panel">
+      <section className="auto-edit-intro"><Scissors size={28} weight="duotone" /><div><strong>{t("autoEditCreateTitle")}</strong><span>{t("autoEditCreateDesc")}</span></div></section>
+      <section className="auto-edit-status-card">
+        <div><span>{t("autoEditBrowserModel")}</span><strong className={`auto-edit-availability is-${availability}`}>{t(`autoEditStatus_${availability}`)}</strong></div>
+        <p>{t("autoEditPrivacyHint")}</p>
+        {languageFallback ? <p className="auto-edit-warning">{t("autoEditLanguageFallback")}</p> : null}
+        <button className="panel-secondary" type="button" disabled={autoEdit?.job?.running || availability === "checking"} onClick={autoEdit?.checkSupport}>{t("autoEditCheckSupport")}</button>
+      </section>
+      <div className="auto-edit-flow"><span>1</span><p><strong>{t("autoEditStepScenes")}</strong><small>{t("autoEditStepScenesHint")}</small></p><span>2</span><p><strong>{t("autoEditStepCaptions")}</strong><small>{t("autoEditStepCaptionsHint")}</small></p><span>3</span><p><strong>{t("autoEditStepTimeline")}</strong><small>{t("autoEditStepTimelineHint")}</small></p></div>
+      {autoEdit?.job?.running ? <div className="auto-edit-progress"><div><span>{autoEdit.job.phase}</span><strong>{autoEdit.job.progress}%</strong></div><progress max="100" value={autoEdit.job.progress} /><button className="panel-secondary" type="button" onClick={autoEdit.cancel}>{t("cancel")}</button></div> : null}
+      <button className="primary-action" type="button" disabled={!hasVisual || !ready || autoEdit?.job?.running} onClick={autoEdit?.run}>{hasVisual ? t("autoEditGenerate") : t("autoEditNeedsVisual")}</button>
+    </div>
+  );
+}
+
 function CaptionContextPanel({
   t,
   captionSegments,
@@ -339,6 +359,7 @@ export function VoicePanel({
   automaticCaptionProgress,
   avatarPanelOpen,
   smartMode = "auto-edit",
+  autoEdit,
   uiLanguage,
   visionAnalysis,
   visionOptions,
@@ -383,7 +404,7 @@ export function VoicePanel({
   const isStickerContext = selectedTrack === "sticker" && Boolean(selectedStickerSegment);
   const selectedCaptionAudioSegment = getCaptionVoiceSegment(audioSegments, selectedCaptionSegment);
   const title = isSmartAutoContext ? t("smartAutoEdit") : isSmartFrameContext ? t("smartFrame") : isAvatarContext ? t("avatarTitle") : isStickerContext ? t("stickerProperties") : isVisualContext ? t("visualPanelTitle") : isCaptionContext ? t("caption") : isAudioClipContext ? t("audioClipProperties") : t("aiVoice");
-  const panelStatusText = isSmartAutoContext ? t("smartComingSoon") : isSmartFrameContext ? (hasVisual ? t("smartVisualReady") : t("smartWaitingVisual")) : isCaptionContext
+  const panelStatusText = isSmartAutoContext ? t(`autoEditStatus_${autoEdit?.support?.availability || "unknown"}`) : isSmartFrameContext ? (hasVisual ? t("smartVisualReady") : t("smartWaitingVisual")) : isCaptionContext
     ? captionSegments.length
       ? `${captionSegments.length} ${t("captionSegmentsUnit", "条字幕")}`
       : t("noCaptionSegments")
@@ -411,6 +432,10 @@ export function VoicePanel({
     });
     return () => cancelAnimationFrame(frame);
   }, [captionVoiceFocusRequest, isCaptionContext]);
+
+  useEffect(() => {
+    panelRef.current?.querySelector(".voice-tab-body")?.scrollTo({ top: 0 });
+  }, [activeTool, smartMode]);
 
   return (
     <aside ref={panelRef} className={`voice-panel ${isCaptionContext ? "is-caption-context" : ""} ${isAvatarContext ? "is-avatar-context" : ""} ${isAudioClipContext ? "is-audio-clip-context" : ""} ${isVisualContext ? "is-visual-context" : ""}`}>
@@ -464,7 +489,7 @@ export function VoicePanel({
       ) : null}
 
       <div className="voice-tab-body">
-        {isSmartAutoContext ? <div className="smart-context-empty"><Scissors size={34} weight="duotone" /><strong>{t("smartAutoWorkspace")}</strong><span>{t("smartAutoWorkspaceEmpty")}</span></div> : null}
+        {isSmartAutoContext ? <AutoEditPanel t={t} hasVisual={hasVisual} language={uiLanguage} autoEdit={autoEdit} /> : null}
         {isSmartFrameContext ? <SmartVisionPanel t={t} language={uiLanguage} hasVisual={hasVisual} visualType={visualType} analysis={visionAnalysis} options={visionOptions} running={visionRunning} progress={visionProgress} phase={visionPhase} onAnalyze={analyzeCurrentVisual} onToggle={toggleVisionOption} onClear={clearVisionAnalysis} onDownloadCutout={downloadVisionCutout} /> : null}
         {isStickerContext ? <StickerContextPanel t={t} segment={selectedStickerSegment} updateStickerSegment={updateStickerSegment} deleteStickerSegment={deleteStickerSegment} /> : null}
         {isVisualContext && selectedVisualSegment ? (

--- a/src/hooks/useAutoEdit.js
+++ b/src/hooks/useAutoEdit.js
@@ -1,0 +1,37 @@
+import { useCallback, useRef, useState } from "react";
+import { extractAutoEditFrames, generateFrameCaptions, probeBuiltInAI } from "../lib/autoEdit.js";
+import { getVisualSegmentsTotal } from "../lib/timeline.js";
+
+export function useAutoEdit({ language, visualSegments, commitCaptionSegments, setCaptionsEnabled, setSelectedSegmentId, setSelectedTrack, notify, t }) {
+  const [support, setSupport] = useState({ availability: "unknown", reason: "", language: "en" });
+  const [job, setJob] = useState({ running: false, progress: 0, phase: "" });
+  const abortRef = useRef(null);
+  const checkSupport = useCallback(async () => {
+    setSupport((value) => ({ ...value, availability: "checking" }));
+    const result = await probeBuiltInAI(language);
+    setSupport(result);
+    return result;
+  }, [language]);
+  const run = useCallback(async () => {
+    if (!visualSegments.length || job.running) return;
+    const environment = support.availability === "unknown" ? await checkSupport() : support;
+    if (environment.availability === "unavailable") return void notify(t("autoEditUnavailable"));
+    abortRef.current = new AbortController();
+    setJob({ running: true, progress: 2, phase: t("autoEditFindingScenes") });
+    try {
+      const frames = await extractAutoEditFrames(visualSegments, (progress) => setJob({ running: true, progress, phase: t("autoEditFindingScenes") }), abortRef.current.signal);
+      setJob({ running: true, progress: 60, phase: t("autoEditWritingCaptions") });
+      const captions = await generateFrameCaptions({ frames, duration: getVisualSegmentsTotal(visualSegments), language, onDownloadProgress: (loaded) => setJob({ running: true, progress: 60 + Math.round(loaded * 20), phase: t("autoEditDownloadingModel") }) });
+      if (!captions.length) throw new Error("No captions generated");
+      commitCaptionSegments(captions);
+      setCaptionsEnabled(true); setSelectedTrack("caption"); setSelectedSegmentId(captions[0].id);
+      setJob({ running: false, progress: 100, phase: t("autoEditDone") });
+      notify(t("autoEditDone"));
+    } catch (error) {
+      if (error?.name !== "AbortError") notify(`${t("autoEditFailed")}: ${error?.message || error}`);
+      setJob({ running: false, progress: 0, phase: "" });
+    }
+  }, [checkSupport, commitCaptionSegments, job.running, language, notify, setCaptionsEnabled, setSelectedSegmentId, setSelectedTrack, support, t, visualSegments]);
+  const cancel = () => { abortRef.current?.abort(); setJob({ running: false, progress: 0, phase: "" }); };
+  return { support, job, checkSupport, run, cancel };
+}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -264,9 +264,15 @@ const SMART_WORKSPACE_COPY = {
   vi: { smartTools: "Công cụ Smart", smartAutoEdit: "Dựng tự động", smartAutoEditHint: "Sắp ra mắt", smartFrame: "Smart Frame", smartFrameHint: "Bố cục thông minh", smartAvatar: "Người kỹ thuật số", smartAvatarHint: "Video đồng bộ môi", smartAutoEditDescription: "Tự động phân tích nội dung, sắp xếp nhịp điệu và tạo bản dựng đầu tiên.", smartPlanning: "Đang lên kế hoạch", smartAutoWorkspace: "Không gian dựng tự động", smartAutoWorkspaceEmpty: "Tính năng sẽ được bổ sung ở giai đoạn tiếp theo. Khu vực này hiện để trống.", smartComingSoon: "Sắp ra mắt", smartVisualReady: "Hình ảnh đã sẵn sàng", smartWaitingVisual: "Đang chờ hình ảnh", smartFrameReadyHint: "Chạy nhận diện và cấu hình Smart Frame từ bảng bên trái.", smartFrameEmptyHint: "Thêm ảnh hoặc video, sau đó chạy Smart Frame từ bảng bên trái." },
 };
 
+const AUTO_EDIT_COPY = {
+  zh: { smartAutoEditHint: "本地生成字幕", autoEditCreateTitle: "从画面生成时间轴字幕", autoEditCreateDesc: "检测镜头变化，抽取代表帧，并交给 Chrome 内置模型生成带时间的字幕。", autoEditBrowserModel: "Chrome 内置模型", autoEditPrivacyHint: "画面在设备本地处理，不上传到项目服务器。首次使用可能需要 Chrome 下载模型。", autoEditLanguageFallback: "Chrome 当前未正式支持中文 Prompt 输出，本次会生成英文字幕；生成后可在字幕轨继续编辑。", autoEditCheckSupport: "检测浏览器支持", autoEditStepScenes: "检测镜头", autoEditStepScenesHint: "按帧差筛选关键画面", autoEditStepCaptions: "理解画面", autoEditStepCaptionsHint: "本地多模态模型生成文案", autoEditStepTimeline: "写入时间轴", autoEditStepTimelineHint: "保留每条字幕的开始与结束时间", autoEditGenerate: "生成画面字幕", autoEditNeedsVisual: "请先添加图片或视频", autoEditFindingScenes: "正在检测镜头变化", autoEditWritingCaptions: "正在生成字幕", autoEditDownloadingModel: "正在下载浏览器模型", autoEditDone: "画面字幕已写入时间轴", autoEditUnavailable: "当前浏览器或设备不支持 Chrome 内置模型", autoEditFailed: "自动剪辑失败", autoEditStatus_unknown: "尚未检测", autoEditStatus_checking: "检测中", autoEditStatus_available: "可用", autoEditStatus_downloadable: "模型待下载", autoEditStatus_downloading: "下载中", autoEditStatus_unavailable: "不可用" },
+  en: { smartAutoEditHint: "Local captions", autoEditCreateTitle: "Create timed captions from visuals", autoEditCreateDesc: "Detect scene changes, sample representative frames, and use Chrome's built-in model to write timed captions.", autoEditBrowserModel: "Chrome built-in model", autoEditPrivacyHint: "Frames are processed on this device and are not sent to the project server. Chrome may download the model on first use.", autoEditLanguageFallback: "The current UI language is not officially supported by Chrome Prompt API output. Captions will be generated in English and remain editable.", autoEditCheckSupport: "Check browser support", autoEditStepScenes: "Detect scenes", autoEditStepScenesHint: "Select key visuals by frame difference", autoEditStepCaptions: "Understand visuals", autoEditStepCaptionsHint: "Generate copy with the local multimodal model", autoEditStepTimeline: "Write timeline", autoEditStepTimelineHint: "Keep caption start and end times", autoEditGenerate: "Generate visual captions", autoEditNeedsVisual: "Add an image or video first", autoEditFindingScenes: "Detecting scene changes", autoEditWritingCaptions: "Writing captions", autoEditDownloadingModel: "Downloading browser model", autoEditDone: "Visual captions added to the timeline", autoEditUnavailable: "Chrome built-in AI is unavailable on this browser or device", autoEditFailed: "Auto Edit failed", autoEditStatus_unknown: "Not checked", autoEditStatus_checking: "Checking", autoEditStatus_available: "Available", autoEditStatus_downloadable: "Model download needed", autoEditStatus_downloading: "Downloading", autoEditStatus_unavailable: "Unavailable" },
+};
+
 export const UI_COPY = {
   zh: {
     ...SMART_WORKSPACE_COPY.zh,
+    ...AUTO_EDIT_COPY.zh,
     ...VISUAL_EDITOR_COPY.zh,
     ...TRANSITION_EDITOR_COPY.zh,
     ...VISUAL_ANIMATION_COPY.zh,
@@ -640,6 +646,7 @@ export const UI_COPY = {
   },
   en: {
     ...SMART_WORKSPACE_COPY.en,
+    ...AUTO_EDIT_COPY.en,
     ...VISUAL_EDITOR_COPY.en,
     ...TRANSITION_EDITOR_COPY.en,
     ...VISUAL_ANIMATION_COPY.en,

--- a/src/i18nTransition.test.js
+++ b/src/i18nTransition.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { APP_LANGUAGES, createTranslator, translateOptionName } from "./i18n.js";
+
+describe("transition editor translations", () => {
+  it("provides editor labels and localized transition names for every UI language", () => {
+    APP_LANGUAGES.forEach(({ id }) => {
+      const t = createTranslator(id);
+      expect(t("transitionSettings")).not.toBe("transitionSettings");
+      expect(t("close")).not.toBe("close");
+      expect(t("duration")).not.toBe("duration");
+      expect(t("secondsShort")).not.toBe("secondsShort");
+      if (id !== "zh") expect(translateOptionName(id, "淡入淡出")).not.toBe("淡入淡出");
+    });
+  });
+});

--- a/src/i18nVisualAnimation.test.js
+++ b/src/i18nVisualAnimation.test.js
@@ -11,6 +11,7 @@ describe("visual animation translations", () => {
       expect(t("stickerProperties")).not.toBe("stickerProperties");
       expect(t("stickerOpacity")).not.toBe("stickerOpacity");
       expect(t("deleteSticker")).not.toBe("deleteSticker");
+      expect(t("newCaptionDefault")).not.toBe("newCaptionDefault");
     }
   });
 });

--- a/src/lib/autoEdit.js
+++ b/src/lib/autoEdit.js
@@ -1,0 +1,136 @@
+import { makeId } from "./timeline.js";
+
+export const BUILT_IN_AI_LANGUAGES = new Set(["en", "es", "ja", "de", "fr"]);
+
+export function getAutoEditLanguage(language = "en") {
+  const normalized = language === "pt" ? "pt-BR" : language;
+  return BUILT_IN_AI_LANGUAGES.has(normalized) ? normalized : "en";
+}
+
+export async function probeBuiltInAI(language = "en") {
+  if (typeof window === "undefined" || !window.LanguageModel) {
+    return { availability: "unavailable", reason: "api-missing", language: getAutoEditLanguage(language) };
+  }
+  const modelLanguage = getAutoEditLanguage(language);
+  try {
+    const availability = await window.LanguageModel.availability({
+      expectedInputs: [{ type: "text", languages: ["en"] }, { type: "image" }],
+      expectedOutputs: [{ type: "text", languages: [modelLanguage] }],
+    });
+    return { availability, reason: "", language: modelLanguage };
+  } catch (error) {
+    return { availability: "unavailable", reason: error?.name || "probe-failed", language: modelLanguage };
+  }
+}
+
+export function selectChangedFrames(frames, { threshold = 0.12, maxFrames = 12 } = {}) {
+  if (!frames.length) return [];
+  const selected = [frames[0]];
+  for (let index = 1; index < frames.length && selected.length < maxFrames; index += 1) {
+    const frame = frames[index];
+    const previous = selected.at(-1);
+    if (frame.segmentId !== previous.segmentId || frame.difference >= threshold) selected.push(frame);
+  }
+  const last = frames.at(-1);
+  if (selected.length < maxFrames && last && selected.at(-1)?.time !== last.time) selected.push(last);
+  return selected;
+}
+
+export function normalizeGeneratedCaptions(value, duration) {
+  const items = Array.isArray(value) ? value : value?.captions;
+  if (!Array.isArray(items)) return [];
+  return items
+    .map((item) => {
+      const start = Math.max(0, Math.min(duration, Number(item.start) || 0));
+      const end = Math.max(start + 0.2, Math.min(duration, Number(item.end) || start + 2));
+      return { id: makeId("caption"), text: String(item.text || "").trim(), start, end, hidden: false };
+    })
+    .filter((item) => item.text)
+    .sort((a, b) => a.start - b.start);
+}
+
+function waitForMedia(element, event) {
+  return new Promise((resolve, reject) => {
+    const done = () => { cleanup(); resolve(); };
+    const fail = () => { cleanup(); reject(element.error || new Error(`Media ${event} failed`)); };
+    const cleanup = () => { element.removeEventListener(event, done); element.removeEventListener("error", fail); };
+    element.addEventListener(event, done, { once: true });
+    element.addEventListener("error", fail, { once: true });
+  });
+}
+
+async function canvasBlob(canvas) {
+  return new Promise((resolve, reject) => canvas.toBlob((blob) => blob ? resolve(blob) : reject(new Error("Frame encoding failed")), "image/jpeg", 0.82));
+}
+
+function pixelDifference(current, previous) {
+  if (!previous) return 1;
+  let sum = 0;
+  for (let index = 0; index < current.length; index += 4) {
+    sum += Math.abs(current[index] - previous[index]);
+    sum += Math.abs(current[index + 1] - previous[index + 1]);
+    sum += Math.abs(current[index + 2] - previous[index + 2]);
+  }
+  return sum / ((current.length / 4) * 3 * 255);
+}
+
+export async function extractAutoEditFrames(segments, onProgress = () => {}, signal) {
+  const frames = [];
+  let timelineStart = 0;
+  for (let segmentIndex = 0; segmentIndex < segments.length; segmentIndex += 1) {
+    if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+    const segment = segments[segmentIndex];
+    const duration = Math.max(0.2, Number(segment.duration) || 0.2);
+    const canvas = document.createElement("canvas");
+    canvas.width = 224; canvas.height = 126;
+    const context = canvas.getContext("2d", { willReadFrequently: true });
+    let previousPixels = null;
+    if (segment.type === "video") {
+      const video = document.createElement("video");
+      video.muted = true; video.preload = "auto"; video.src = segment.src;
+      if (video.readyState < 1) await waitForMedia(video, "loadedmetadata");
+      const sourceStart = Number(segment.sourceStart) || 0;
+      const sourceDuration = Math.max(0.2, Number(segment.sourceDuration) || video.duration || duration);
+      const sampleCount = Math.min(30, Math.max(3, Math.ceil(duration * 1.5)));
+      for (let sample = 0; sample < sampleCount; sample += 1) {
+        const ratio = sampleCount === 1 ? 0 : sample / (sampleCount - 1);
+        video.currentTime = Math.min(Math.max(0, video.duration - 0.05), sourceStart + ratio * sourceDuration);
+        await waitForMedia(video, "seeked");
+        context.drawImage(video, 0, 0, canvas.width, canvas.height);
+        const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
+        frames.push({ segmentId: segment.id, time: timelineStart + ratio * duration, difference: pixelDifference(pixels, previousPixels), blob: await canvasBlob(canvas) });
+        previousPixels = new Uint8ClampedArray(pixels);
+      }
+      video.removeAttribute("src"); video.load();
+    } else if (segment.src) {
+      const image = new Image(); image.src = segment.src;
+      if (!image.complete) await waitForMedia(image, "load");
+      context.drawImage(image, 0, 0, canvas.width, canvas.height);
+      frames.push({ segmentId: segment.id, time: timelineStart, difference: 1, blob: await canvasBlob(canvas) });
+    }
+    timelineStart += duration;
+    onProgress(Math.round(((segmentIndex + 1) / segments.length) * 55));
+  }
+  return selectChangedFrames(frames);
+}
+
+export async function generateFrameCaptions({ frames, duration, language, onDownloadProgress }) {
+  const modelLanguage = getAutoEditLanguage(language);
+  const options = {
+    expectedInputs: [{ type: "text", languages: ["en"] }, { type: "image" }],
+    expectedOutputs: [{ type: "text", languages: [modelLanguage] }],
+    monitor(monitor) {
+      monitor.addEventListener("downloadprogress", (event) => onDownloadProgress?.(event.loaded));
+    },
+  };
+  const session = await window.LanguageModel.create(options);
+  try {
+    const content = [{ type: "text", value: `Create concise on-screen captions for these chronological video frames. Output in ${modelLanguage}. Use only visible evidence, do not invent names or facts. Frame timestamps: ${frames.map((frame) => frame.time.toFixed(2)).join(", ")} seconds. Keep each caption on screen for 1.5 to 4 seconds and within 0 to ${duration.toFixed(2)} seconds.` }];
+    frames.forEach((frame) => content.push({ type: "image", value: frame.blob }));
+    const schema = { type: "object", properties: { captions: { type: "array", items: { type: "object", properties: { start: { type: "number" }, end: { type: "number" }, text: { type: "string" } }, required: ["start", "end", "text"], additionalProperties: false } } }, required: ["captions"], additionalProperties: false };
+    const response = await session.prompt([{ role: "user", content }], { responseConstraint: schema });
+    return normalizeGeneratedCaptions(JSON.parse(response), duration);
+  } finally {
+    session.destroy?.();
+  }
+}

--- a/src/lib/autoEdit.test.js
+++ b/src/lib/autoEdit.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getAutoEditLanguage, normalizeGeneratedCaptions, selectChangedFrames } from "./autoEdit.js";
+
+describe("auto edit", () => {
+  it("keeps scene changes and clip boundaries", () => {
+    const frames = [{ segmentId: "a", time: 0, difference: 1 }, { segmentId: "a", time: 1, difference: .03 }, { segmentId: "a", time: 2, difference: .3 }, { segmentId: "b", time: 3, difference: .01 }];
+    expect(selectChangedFrames(frames).map((frame) => frame.time)).toEqual([0, 2, 3]);
+  });
+  it("falls back to an officially supported output language", () => expect(getAutoEditLanguage("zh")).toBe("en"));
+  it("clamps and sorts generated captions", () => {
+    const result = normalizeGeneratedCaptions({ captions: [{ start: 4, end: 9, text: "B" }, { start: -2, end: 1, text: "A" }] }, 5);
+    expect(result.map(({ text, start, end }) => ({ text, start, end }))).toEqual([{ text: "A", start: 0, end: 1 }, { text: "B", start: 4, end: 5 }]);
+  });
+});

--- a/src/lib/sourceAudioSync.js
+++ b/src/lib/sourceAudioSync.js
@@ -18,7 +18,7 @@ export function getLinkedSourceAudioSegments(visualSegments = [], sourceAudioAss
   const timeline = getVisualSegmentTimeline(visualSegments);
   const maximumSourceTime = Math.max(0, Number(sourceAudioDuration) || 0);
   return visualSegments.flatMap((segment, index) => {
-    if (segment.type !== "video" || (!hasMappedOffsets && segment.assetId !== linkedAssetId)) return [];
+    if (segment.type !== "video" || segment.sourceAudioDisabled || (!hasMappedOffsets && segment.assetId !== linkedAssetId)) return [];
     const range = timeline[index];
     const playbackRate = normalizeVisualPlaybackRate(segment.playbackRate);
     const sourceStart = Math.max(0, Number(segment.sourceAudioOffset) || 0) + Math.max(0, Number(segment.sourceStart) || 0);

--- a/src/lib/sourceAudioSync.test.js
+++ b/src/lib/sourceAudioSync.test.js
@@ -37,4 +37,13 @@ describe("linked source audio", () => {
     expect(getLinkedSourceAudioState(segments, 2)).toMatchObject({ active: true, sourceTime: 2 });
     expect(getLinkedSourceAudioState(segments, 5)).toMatchObject({ active: true, sourceTime: 5 });
   });
+
+  it("omits only the linked audio piece disabled on its visual clip", () => {
+    const segments = getLinkedSourceAudioSegments(
+      visualSegments.map((segment) => segment.id === "a" ? { ...segment, sourceAudioDisabled: true } : segment),
+      "video-1",
+      6,
+    );
+    expect(segments.map((segment) => segment.id)).toEqual(["c"]);
+  });
 });

--- a/src/lib/timelineClipboardActions.js
+++ b/src/lib/timelineClipboardActions.js
@@ -30,7 +30,21 @@ export function createTimelineClipboardActions(d) {
       const id = d.selectedAudioSegmentId || d.selectedAudioSegment?.id;
       return id ? void d.deleteAudioSegment(id) : void d.notify("当前没有选中的配音片段");
     }
-    if (d.selectedTrack === "source") return void d.clearSourceAudioTrack();
+    if (d.selectedTrack === "source") {
+      if (d.sourceAudioLinked && d.selectedSourceAudioSegmentId && d.selectedSourceAudioSegmentId !== "source-audio") {
+        const index = d.visualSegments.findIndex((segment) => segment.id === d.selectedSourceAudioSegmentId);
+        if (index < 0) return void d.notify("当前没有选中的原声音频片段");
+        const next = d.visualSegments.map((segment, position) => position === index
+          ? { ...segment, sourceAudioDisabled: true }
+          : segment);
+        d.commitVisualSegments(next, "已删除当前原声音频片段", Math.max(0, index));
+        d.setSelectedSourceAudioSegmentId("");
+        return;
+      }
+      if (!d.selectedSourceAudioSegmentId) return void d.notify("当前没有选中的原声音频片段");
+      d.setSelectedSourceAudioSegmentId("");
+      return void d.clearSourceAudioTrack("已删除当前原声音频片段");
+    }
     if (d.selectedTrack === "music") return void d.clearMusicTrack();
     d.clearImageTrack();
   };

--- a/src/lib/timelineSegmentCountActions.js
+++ b/src/lib/timelineSegmentCountActions.js
@@ -58,7 +58,7 @@ export function createTimelineSegmentCountActions(d) {
     if (["audio", "source", "music"].includes(d.selectedTrack)) return void d.notify(d.selectedTrack === "music" ? "背景音乐暂不支持切片，请删除后重新上传" : d.selectedTrack === "source" ? "视频原声暂不支持切片，可删除后重新上传视频" : "音频片段由生成结果决定，请重新生成或复制 WAV");
     const insertionTime = Number.isFinite(requestedStart) ? requestedStart : d.currentTime;
     const start = Math.max(0, Math.min(MAX_TIMELINE_DURATION_SECONDS - 0.45, insertionTime));
-    const segment = { id: makeId("caption"), text: "新的字幕片段", weight: 1, hidden: false,
+    const segment = { id: makeId("caption"), text: d.t?.("newCaptionDefault") ?? "新的字幕片段", weight: 1, hidden: false,
       start, end: Math.min(MAX_TIMELINE_DURATION_SECONDS, start + 1.8) };
     const next = [...d.captionSegments, segment].sort((a, b) => (Number(a.start) || 0) - (Number(b.start) || 0));
     d.commitCaptionSegments(next, Number.isFinite(requestedStart) ? "已在点击位置新增字幕片段" : "已在播放头位置新增字幕片段", next.findIndex((item) => item.id === segment.id));

--- a/src/lib/timelineSegmentCountActions.test.js
+++ b/src/lib/timelineSegmentCountActions.test.js
@@ -7,10 +7,10 @@ describe("timeline segment insertion", () => {
     const commitCaptionSegments = vi.fn();
     const controls = createTimelineSegmentCountActions({
       selectedTrack: "caption", currentTime: 4.25, captionSegments: [], trackLocks: {},
-      commitCaptionSegments, notify: vi.fn(),
+      commitCaptionSegments, notify: vi.fn(), t: (key) => key === "newCaptionDefault" ? "New caption" : key,
     });
     controls.handleAddSegment();
-    expect(commitCaptionSegments.mock.calls[0][0][0]).toMatchObject({ start: 4.25, end: 6.05 });
+    expect(commitCaptionSegments.mock.calls[0][0][0]).toMatchObject({ start: 4.25, end: 6.05, text: "New caption" });
   });
 
   it("splits the active visual and inserts the new clip at the playhead", () => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1154,6 +1154,30 @@ button:disabled {
 .smart-context-empty svg { color: #5c7280; }
 .smart-context-empty strong { margin-top: 15px; color: #e3edef; font-size: 14px; }
 .smart-context-empty span { max-width: 240px; margin-top: 8px; color: #798894; font-size: 11px; line-height: 1.6; }
+.auto-edit-panel { display: grid; gap: 14px; }
+.auto-edit-intro { display: flex; gap: 12px; align-items: center; padding: 14px; border: 1px solid rgba(53,234,217,.16); border-radius: 11px; background: linear-gradient(145deg, rgba(53,234,217,.1), rgba(77,128,255,.05)); }
+.auto-edit-intro svg { flex: 0 0 auto; color: #35ead9; }
+.auto-edit-intro div { display: grid; gap: 4px; }
+.auto-edit-intro strong { color: #edf8f7; font-size: 13px; }
+.auto-edit-intro span, .auto-edit-status-card p { color: #82919b; font-size: 11px; line-height: 1.55; }
+.auto-edit-status-card { display: grid; gap: 10px; padding: 13px; border: 1px solid rgba(255,255,255,.08); border-radius: 10px; background: rgba(255,255,255,.025); }
+.auto-edit-status-card > div { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.auto-edit-status-card > div > span { color: #c1cdd2; font-size: 12px; }
+.auto-edit-status-card p { margin: 0; }
+.auto-edit-status-card .auto-edit-warning { color: #d8b96e; }
+.auto-edit-availability { color: #82919b; font-size: 10px; }
+.auto-edit-availability.is-available { color: #35ead9; }
+.auto-edit-availability.is-unavailable { color: #f27e7e; }
+.auto-edit-availability.is-downloadable, .auto-edit-availability.is-downloading { color: #e7c56f; }
+.auto-edit-flow { display: grid; grid-template-columns: 24px minmax(0,1fr); gap: 10px 9px; align-items: start; }
+.auto-edit-flow > span { display: grid; place-items: center; width: 24px; height: 24px; border-radius: 50%; color: #071616; font-size: 10px; font-weight: 700; background: #35ead9; }
+.auto-edit-flow p { display: grid; gap: 2px; margin: 0; }
+.auto-edit-flow strong { color: #dce7e9; font-size: 12px; }
+.auto-edit-flow small { color: #74838e; font-size: 10px; }
+.auto-edit-progress { display: grid; gap: 8px; }
+.auto-edit-progress > div { display: flex; justify-content: space-between; color: #9eacb4; font-size: 11px; }
+.auto-edit-progress progress { width: 100%; accent-color: #35ead9; }
+.auto-edit-panel .primary-action { width: 100%; }
 
 .smart-vision-heading {
   display: flex;
@@ -3764,7 +3788,7 @@ button:disabled {
 
 .visual-junction {
   position: absolute;
-  top: 15px;
+  top: 27px;
   z-index: 8;
   display: grid;
   place-items: center;
@@ -3875,10 +3899,14 @@ button:disabled {
 }
 
 .image-clip.is-selected-segment {
-  border-color: rgba(105, 168, 255, 0.92);
+  z-index: 4;
+  border-color: #8bacff;
+  outline: 1px solid rgba(139, 172, 255, 0.82);
+  outline-offset: -2px;
+  filter: brightness(1.07) saturate(1.06);
   box-shadow:
-    inset 0 0 0 1px rgba(105, 168, 255, 0.36),
-    0 0 0 1px rgba(105, 168, 255, 0.28);
+    inset 0 0 0 1px rgba(210, 224, 255, 0.18),
+    0 0 8px rgba(90, 139, 255, 0.24);
 }
 
 .image-thumbnails {
@@ -4087,9 +4115,14 @@ button:disabled {
 }
 
 .caption-segment.is-selected-segment {
+  z-index: 4;
+  border-color: #ffad6b;
+  outline: 1px solid rgba(255, 173, 107, 0.82);
+  outline-offset: -2px;
+  filter: brightness(1.06);
   box-shadow:
-    inset 0 0 0 2px #67b5ff,
-    0 0 0 1px rgba(103, 181, 255, 0.4);
+    inset 0 0 0 1px rgba(255, 229, 207, 0.16),
+    0 0 8px rgba(255, 137, 72, 0.22);
 }
 
 .caption-segment-label {
@@ -4161,10 +4194,14 @@ button:disabled {
 }
 
 .sticker-segment.is-selected-segment {
-  border-color: rgba(103, 181, 255, 0.9);
+  z-index: 4;
+  border-color: #35ead9;
+  outline: 1px solid rgba(53, 234, 217, 0.82);
+  outline-offset: -2px;
+  filter: brightness(1.06);
   box-shadow:
-    inset 0 0 0 1px rgba(103, 181, 255, 0.36),
-    0 0 0 1px rgba(103, 181, 255, 0.28);
+    inset 0 0 0 1px rgba(205, 255, 250, 0.16),
+    0 0 8px rgba(53, 234, 217, 0.2);
 }
 
 .sticker-segment img {
@@ -4356,8 +4393,29 @@ button:disabled {
 }
 
 .audio-clip.is-selected .waveform-strip {
-  border-color: rgba(105, 170, 255, 0.95);
-  box-shadow: inset 0 0 0 1px rgba(105, 170, 255, 0.45);
+  border-color: #b493ff;
+  outline: 1px solid rgba(180, 147, 255, 0.82);
+  outline-offset: -2px;
+  filter: brightness(1.07) saturate(1.05);
+  box-shadow:
+    inset 0 0 0 1px rgba(230, 219, 255, 0.16),
+    0 0 8px rgba(153, 109, 255, 0.22);
+}
+
+.audio-clip.is-source.is-selected .waveform-strip {
+  border-color: #ffd45f;
+  outline-color: #ffd45f;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 241, 198, 0.18),
+    0 0 8px rgba(255, 190, 55, 0.24);
+}
+
+.audio-clip.is-music.is-selected .waveform-strip {
+  border-color: #65ddb0;
+  outline-color: #65ddb0;
+  box-shadow:
+    inset 0 0 0 1px rgba(210, 255, 238, 0.17),
+    0 0 8px rgba(66, 211, 157, 0.22);
 }
 
 .audio-clip.is-source .waveform-strip {


### PR DESCRIPTION
## What changed

- adds the Auto Edit workflow and its editor integration
- internationalizes transition controls and related Smart workspace copy
- makes timeline clip selection globally exclusive with track-specific highlights
- deletes only the selected linked source-audio piece instead of clearing the full track
- moves the visual transition junction control away from the playhead marker

## Why

These changes complete the updated Smart workspace direction and fix timeline selection, deletion, and overlap issues found during interaction testing.

## Validation

- 77 Vitest tests passed
- production Vite build passed
- branch is based on the latest origin/main