### PR TITLE
Add support links to localized READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -37,7 +37,10 @@ npm run build
 npm run check
 ```
 
+## Unterstützung und Feedback
+
+Wenn dir dieses Projekt hilft, gib ihm gerne einen ⭐ Star. Wenn du auf ein Problem stößt, [erstelle bitte ein Issue](https://github.com/MartinDelophy/ai-video-editor/issues).
+
 ## Lizenz
 
 [MIT](LICENSE)
-

--- a/README.es.md
+++ b/README.es.md
@@ -37,7 +37,10 @@ npm run build
 npm run check
 ```
 
+## Apoyo y comentarios
+
+Si este proyecto te resulta útil, considera darle una ⭐ Star. Si encuentras algún problema, [abre un Issue](https://github.com/MartinDelophy/ai-video-editor/issues).
+
 ## Licencia
 
 [MIT](LICENSE)
-

--- a/README.fr.md
+++ b/README.fr.md
@@ -37,7 +37,10 @@ npm run build
 npm run check
 ```
 
+## Soutien et retours
+
+Si ce projet vous est utile, n'hésitez pas à lui attribuer une ⭐ Star. Si vous rencontrez un problème, [ouvrez une Issue](https://github.com/MartinDelophy/ai-video-editor/issues).
+
 ## Licence
 
 [MIT](LICENSE)
-

--- a/README.ja.md
+++ b/README.ja.md
@@ -37,7 +37,10 @@ npm run build
 npm run check
 ```
 
+## サポートとフィードバック
+
+このプロジェクトが役に立ったら、ぜひ ⭐ Star をお願いします。問題が発生した場合は、[Issue を作成してください](https://github.com/MartinDelophy/ai-video-editor/issues)。
+
 ## ライセンス
 
 [MIT](LICENSE)
-

--- a/README.ko.md
+++ b/README.ko.md
@@ -37,7 +37,10 @@ npm run build
 npm run check
 ```
 
+## 지원 및 피드백
+
+이 프로젝트가 도움이 되었다면 ⭐ Star를 눌러 주세요. 문제가 발생하면 [Issue를 등록해 주세요](https://github.com/MartinDelophy/ai-video-editor/issues).
+
 ## 라이선스
 
 [MIT](LICENSE)
-

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ The included [`netlify.toml`](netlify.toml) builds with `npm run build`, publish
 npx netlify-cli deploy --prod --dir=dist
 ```
 
+## Support and feedback
+
+If this project helps you, please consider giving it a ⭐ Star. If you encounter a problem, please [open an Issue](https://github.com/MartinDelophy/ai-video-editor/issues).
+
 ## License
 
 [MIT](LICENSE)

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -37,7 +37,10 @@ npm run build
 npm run check
 ```
 
+## Apoio e feedback
+
+Se este projeto for útil para você, considere dar uma ⭐ Star. Se encontrar algum problema, [abra uma Issue](https://github.com/MartinDelophy/ai-video-editor/issues).
+
 ## Licença
 
 [MIT](LICENSE)
-

--- a/README.ru.md
+++ b/README.ru.md
@@ -37,7 +37,10 @@ npm run build
 npm run check
 ```
 
+## Поддержка и обратная связь
+
+Если этот проект оказался вам полезен, поставьте ему ⭐ Star. Если вы столкнулись с проблемой, [создайте Issue](https://github.com/MartinDelophy/ai-video-editor/issues).
+
 ## Лицензия
 
 [MIT](LICENSE)
-

--- a/README.th.md
+++ b/README.th.md
@@ -37,7 +37,10 @@ npm run build
 npm run check
 ```
 
+## การสนับสนุนและข้อเสนอแนะ
+
+หากโปรเจกต์นี้มีประโยชน์กับคุณ โปรดกด ⭐ Star หากพบปัญหา โปรด[เปิด Issue](https://github.com/MartinDelophy/ai-video-editor/issues)
+
 ## สัญญาอนุญาต
 
 [MIT](LICENSE)
-

--- a/README.vi.md
+++ b/README.vi.md
@@ -37,7 +37,10 @@ npm run build
 npm run check
 ```
 
+## Hỗ trợ và phản hồi
+
+Nếu dự án này hữu ích với bạn, hãy cân nhắc tặng dự án một ⭐ Star. Nếu gặp vấn đề, vui lòng [mở một Issue](https://github.com/MartinDelophy/ai-video-editor/issues).
+
 ## Giấy phép
 
 [MIT](LICENSE)
-

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,6 +81,10 @@ npm run check
 npx netlify-cli deploy --prod --dir=dist
 ```
 
+## 支持与反馈
+
+如果这个项目对你有帮助，欢迎点亮 ⭐ Star；遇到问题请[提交 Issue](https://github.com/MartinDelophy/ai-video-editor/issues)。
+
 ## License
 
 [MIT](LICENSE)

--- a/huggingface-space/README.md
+++ b/huggingface-space/README.md
@@ -25,3 +25,5 @@ This Space is the lightweight showcase for Timeline Studio, an MIT-licensed,
 local-first AI video editor. The full editor runs at
 [video-editor.ai-creator.top](https://video-editor.ai-creator.top/), and its
 source is available on [GitHub](https://github.com/MartinDelophy/ai-video-editor).
+
+If this project helps you, please consider giving it a ⭐ Star. If you encounter a problem, please [open an Issue](https://github.com/MartinDelophy/ai-video-editor/issues).


### PR DESCRIPTION
## What changed

- Added localized support and feedback sections to all 11 project README variants.
- Added a matching Star and Issue prompt to the Hugging Face Space README.
- Linked every Issue prompt directly to the repository issue tracker.

## Why

Make it easier for users who benefit from Timeline Studio to support the project and report problems from every localized README.

## Validation

- `git diff --cached --check` passed before commit.
- Confirmed all 12 README files contain the new prompt.