### PR TITLE
Release Timeline Studio v0.5.0 mobile workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-player",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-player",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@diffusionstudio/vits-web": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-player",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "description": "A local-first browser AI video editor for voiceovers, captions, talking avatars, and multi-track timeline export.",
   "license": "MIT",

--- a/skills/edit-timeline-studio/SKILL.md
+++ b/skills/edit-timeline-studio/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: edit-timeline-studio
-description: Plan, execute, and verify editable video timelines in the Timeline Studio browser editor at https://video-editor.ai-creator.top/ or in its local repository. Use when the user asks an agent to assemble, trim, reorder, caption, voice, overlay, restyle, or export a video through the website, this repository, or a .timeline project archive.
+description: Operate, evaluate, and improve editable video workflows in Timeline Studio at https://video-editor.ai-creator.top/, its local repository, or a .timeline archive. Use when Codex must import, assemble, trim, reorder, caption, voice, overlay, restyle, save, export, or repeatedly end-to-end test Timeline Studio; also use when real editing experience should be converted into updates to this skill.
 ---
 
 # Edit Timeline Studio
@@ -10,11 +10,11 @@ Turn the user's exact editorial request and media into reversible Timeline Studi
 ## Choose the execution path
 
 1. Treat `https://video-editor.ai-creator.top/` as the canonical hosted editor. When the user asks to use the website, provides no repository, or expects Browser Use, proactively open this URL and inspect the live editor before planning the edit.
-2. When this repository is available and the task concerns local development or unpublished changes, start the local editor and use it instead of the hosted release.
-3. Look for a Timeline Studio command runner with `npm run agent:help` or the documented equivalent.
-4. If it exists, use the command plan in [references/command-contract.md](references/command-contract.md). Validate the plan before applying it.
-5. If it does not exist, use the selected editor UI in a browser as a compatibility path. Import media, perform the edits, and visually verify the preview and timeline.
-6. Do not claim deterministic Agent execution when only UI automation was available. Report that limitation and preserve the project archive.
+2. When this repository is available and the task concerns local development, unpublished changes, or evaluation, start the local editor and use it instead of the hosted release. Read the actual server URL from the process output; never assume port 5173.
+3. Inspect `package.json` for an Agent command script. Do not use `npm run ... --if-present` as capability detection because it can succeed silently.
+4. If the command runner exists, read [references/command-contract.md](references/command-contract.md), build and validate a versioned plan, dry-run it, then apply it.
+5. Otherwise, read [references/browser-workflow.md](references/browser-workflow.md) and use the editor UI. Use a concise edit checklist rather than inventing stable IDs, revisions, transactions, or a JSON plan that the UI cannot honor.
+6. Do not claim deterministic or idempotent execution when only UI automation was available. State the limitation and preserve an editable project archive when the UI supports it.
 
 ## Workflow
 
@@ -26,14 +26,12 @@ Turn the user's exact editorial request and media into reversible Timeline Studi
 - Read the current project summary before changing an existing project.
 - Ask only when an unresolved choice materially changes the edit, such as the desired output duration or aspect ratio.
 
-### 2. Build a plan
+### 2. Plan at the supported fidelity
 
-- Express edits as declarative operations with stable IDs, explicit times in seconds, and expected preconditions.
-- Prefer semantic operations such as `trim`, `split`, `move`, `add_caption`, and `set_property`; avoid pointer coordinates.
+- With the command runner, express edits as declarative operations with stable IDs, seconds, revisions, operation IDs, and preconditions. Validate them with `scripts/validate_edit_plan.mjs <plan.json>`.
+- With browser UI only, write a short ordered checklist of visible user intents and expected UI outcomes. Prefer named controls and clip labels; use coordinates only as a last-resort fallback grounded in a current screenshot.
 - Keep main Visuals contiguous. Treat captions, stickers, source audio, voiceover, music, and overlays as timed clips.
 - Preserve media identity and source-time mapping when moving or trimming clips.
-- Include project revision and operation IDs so retries are idempotent.
-- Validate JSON plans with `scripts/validate_edit_plan.mjs <plan.json>`.
 
 ### 3. Apply safely
 
@@ -47,16 +45,22 @@ Turn the user's exact editorial request and media into reversible Timeline Studi
 
 - Re-read the timeline summary and compare it with the requested duration, ordering, track placement, and enabled states.
 - Preview the opening, every cut or transition, caption boundaries, overlays, and the final frame.
-- Check that audible tracks exist and mute/link state matches the request.
+- Check audible behavior, not just visible tracks. Distinguish embedded video audio from explicitly separated source-audio clips and verify mute/link state.
 - For final export, verify container, dimensions, duration, decoded frames, visible overlays/captions, and a real audio track.
 - Return the editable project path and final render path when created.
 
-## UI compatibility path
+## Interpret underspecified requests conservatively
 
-Open `https://video-editor.ai-creator.top/` proactively when the hosted editor is the selected execution path. Do not search for unofficial mirrors or substitute another editor. Use browser control only until the command runner exists. Operate named controls and visible clip labels, not brittle screen coordinates. After each meaningful edit, confirm the timeline changed as intended. Export a `.timeline` project archive before handing off.
+- For “try it,” “open it,” or “let me edit” requests without an editorial brief, start the editor, import only the explicitly named assets, verify automatic placement, and hand off the live editable workspace.
+- Do not invent trims, captions, aspect-ratio changes, AI generation, or exports.
+- Treat persistent onboarding completion, model downloads, remote generation, and destructive reset as separate user decisions.
+
+## Learn from every real run
+
+For editor evaluation, regression work, or any run that exposes friction, read [references/e2e-evaluation.md](references/e2e-evaluation.md). Capture the attempted action, observed result, evidence, fallback, and verification. Classify the finding as product, browser-control, environment, or skill guidance. Update the smallest relevant skill instruction or reference, validate the skill, reinstall the local copy, and rerun the affected scenario plus adjacent smoke tests. Never weaken an assertion merely to make a test pass.
 
 ## Capability boundaries
 
-Read [references/current-capabilities.md](references/current-capabilities.md) when deciding whether a request can be executed now. Read [references/command-contract.md](references/command-contract.md) when implementing or invoking the Agent command layer.
+Read [references/current-capabilities.md](references/current-capabilities.md) when deciding whether a request can be executed now. Read [references/command-contract.md](references/command-contract.md) only when implementing or invoking the Agent command layer. Read [references/browser-workflow.md](references/browser-workflow.md) for UI execution and [references/e2e-evaluation.md](references/e2e-evaluation.md) for repeated experience-driven testing.
 
 If a requested operation is unsupported, keep the valid partial timeline unchanged and state the exact missing command or runtime capability.

--- a/skills/edit-timeline-studio/agents/openai.yaml
+++ b/skills/edit-timeline-studio/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Timeline Studio Agent Editor"
-  short_description: "Plan, execute, and verify editable timeline video projects"
-  default_prompt: "Use $edit-timeline-studio to edit these media assets into a polished timeline project."
+  short_description: "Edit and repeatedly test Timeline Studio workflows"
+  default_prompt: "Use $edit-timeline-studio to edit these assets, verify the result end to end, and improve the workflow from observed friction."

--- a/skills/edit-timeline-studio/references/browser-workflow.md
+++ b/skills/edit-timeline-studio/references/browser-workflow.md
@@ -1,0 +1,47 @@
+# Browser workflow
+
+Use this path only when the command runner is unavailable.
+
+## Start and select the editor
+
+1. In a local repository, run the existing development command and keep the process alive.
+2. Read the actual URL from the server output. Ports may shift when the default is occupied.
+3. Open that URL in the selected browser and confirm the page is Timeline Studio before importing media. A newly opened tab may start with an empty in-memory project even when another tab previously displayed “Autosaved.”
+4. On the hosted path, use only `https://video-editor.ai-creator.top/`.
+5. Inspect the current project before changing it. Do not reset or replace existing work without authorization. Treat “Autosaved” as session state, not proof that local File/Blob media can be reconstructed in a new tab.
+
+## Import one explicit asset
+
+1. Resolve the requested file to an absolute path and probe its media type, dimensions, duration, frame rate, and audio streams.
+2. Follow the browser tool's file-upload documentation. Begin listening for the file chooser before activating an upload control.
+3. Prefer the visible upload drop zone or visible upload button. If that does not emit a chooser, try the media-specific `input[type=file]`.
+4. If semantic activation fails twice, take a current screenshot and use one coordinate click on the visible upload surface while the chooser listener is active. Do not reuse stale coordinates.
+5. Upload only the explicitly resolved asset. Never sweep a directory.
+6. Verify the asset card filename, dimensions, displayed duration, project duration, and resulting timeline clip.
+7. Remember that only the first imported visual is automatically placed on Visuals. Later imports remain assets until explicitly dragged.
+
+## Handle onboarding without stealing the user's decision
+
+The first visual may open a shortcuts coach guide. Do not click an action that permanently records completion unless the user explicitly asked. For autonomous editing, dismiss it only for the current page session with the corner close control or Escape. If locator-scoped Escape fails because focus moved, take a fresh snapshot and send one page-level Escape keypress. Verify the dialog disappeared. For a handoff or trial request, leave the guide visible.
+
+## Edit through visible state
+
+- Pause or seek only when the requested interaction requires it; timeline drag behavior may intentionally pause after the drag threshold.
+- After each edit, verify the authoritative UI signal: clip range, selected value, visible timeline placement, preview frame, toast, or dialog state.
+- After splitting a narrow clip, do not infer selection from inspector time or a toolbar's active styling. Right-click the intended clip body, verify its clip context menu opened, and use the menu's clip-scoped action. If the wrong clip is changed, undo immediately and reselect through the context menu.
+- For direct manipulation, use a fresh screenshot and verify the resulting numeric transform values where available.
+- Preserve the user's playhead unless the requested operation requires a seek.
+- Save an editable `.timeline` archive before a destructive batch and before final handoff when supported. Reopen that archive when persistence matters; do not rely on a fresh tab restoring local media blobs. A browser-control download event may time out even though the file was saved; after a timeout, inspect the UI and the expected download directory for a newly created non-empty artifact before retrying.
+
+## Verify audio correctly
+
+- A newly imported video can play embedded audio without a visible source-audio lane.
+- Separating audio creates derived source-audio clips and mutes embedded playback to prevent doubling.
+- Deleting a separated piece does not imply that the original visual has lost its embedded audio.
+- Verify audible playback, clip mute state, separation state, and exported audio instead of treating lane visibility as proof.
+
+## Handoff
+
+For a trial request with no edit brief, leave the editor open with the requested media imported and do not export. Report the media facts, automatic placement, current duration, and any visible onboarding guide. For completed edits, return both the editable project and rendered file when created.
+
+For rendered video, decode the entire video stream and probe frame count, dimensions, codec, duration, and audio streams. Confirm audio has real samples or measurable non-silent signal when sound is expected. Compare timeline duration with decoded video duration using a practical tolerance of `max(0.1 seconds, 2 / fps)` to allow frame rounding and audio-container padding.

--- a/skills/edit-timeline-studio/references/current-capabilities.md
+++ b/skills/edit-timeline-studio/references/current-capabilities.md
@@ -19,6 +19,18 @@
 
 Browser-driven editing is a compatibility mechanism, not a stable public API. UI labels, selection state, drag thresholds, and file pickers make it unsuitable for unattended or idempotent jobs.
 
+Observed browser-path constraints:
+
+- Vite may select a different port when the default is occupied; use the emitted URL.
+- A semantically located Choose File button or file input may fail to emit a chooser in browser control even when the visible upload surface succeeds.
+- The first imported visual opens a coach guide whose confirmation persists; an Agent must not confirm it on the user's behalf.
+- A video with embedded audio can be audible without a visible source-audio lane.
+- The first imported visual auto-enters Visuals, while later imported visuals remain in the asset library until placed.
+- Opening a new tab can produce an empty project even after another tab showed “Autosaved”; portable persistence requires an explicit `.timeline` archive because local File/Blob media may not be reconstructed from session autosave.
+- Locator-scoped Escape can fail on the coach dialog when browser focus moves; a verified page-level Escape works as a session-only dismissal.
+- After splitting a very short visual, toolbar selection can be misread; a right-click clip menu provides a safer clip-scoped delete path.
+- Browser-control download events can time out even when `.timeline` or video files are successfully written; confirm with filesystem timestamps and media decoding before retrying.
+
 ## Missing for reliable Agent editing
 
 1. A headless command runner that owns project load, media probing, command application, save, and render.

--- a/skills/edit-timeline-studio/references/e2e-evaluation.md
+++ b/skills/edit-timeline-studio/references/e2e-evaluation.md
@@ -1,0 +1,56 @@
+# End-to-end evaluation loop
+
+Use real browser interactions and real media. Unit tests and DOM assertions supplement this loop but do not replace it.
+
+## Required loop
+
+1. Define one user-visible scenario, its fixture, starting state, and expected outcome.
+2. Run it from a fresh project and capture concise evidence at every meaningful boundary.
+3. Record the first failed action exactly; do not hide it behind the successful fallback.
+4. Classify the cause:
+   - `product`: editor behavior or accessibility contract is wrong;
+   - `browser-control`: the automation surface behaves differently from normal UI input;
+   - `environment`: port, codec, model, browser, network, or filesystem condition;
+   - `skill`: guidance was missing, ambiguous, stale, or overly confident.
+5. Fix the product or update the smallest relevant Skill section. Do not encode a product bug as permanent workflow guidance when the product can be fixed.
+6. Run the skill validator, synchronize the installed copy, rerun the failed scenario, then run adjacent smoke scenarios.
+7. Preserve raw screenshots, console errors, media probes, downloads, and project archives outside the Skill directory when they materially explain a failure.
+
+## Core scenario matrix
+
+Run these across empty and pre-populated projects where applicable:
+
+1. Start the local server with the default port free and occupied; open the actual emitted URL.
+2. Import the first image, first video with audio, video without audio, and audio-only asset.
+3. Import a second visual and verify it remains in the asset library until explicitly placed.
+4. Exercise visible upload controls, file-input fallback, drag/drop, rejected type, duplicate filename, and canceled chooser.
+5. Verify the first-visual coach guide: persistent completion only through the user's explicit action; temporary dismissal through close or Escape.
+6. Trim, split, reorder, delete, undo, redo, save, reopen, and compare media identity and source-time mapping. Include a sub-second split where mute controls and handles consume most of the clip width; verify clip-scoped context-menu deletion and immediate recovery from a deliberately detected wrong-target action.
+7. Add and move captions, stickers, voiceover, music, source audio, and picture-in-picture; verify lane visibility and overlap packing.
+8. Verify embedded video audio, mute, Separate audio, derived-piece deletion, link modes, preview playback, and export without doubled or missing sound.
+9. Change transforms, masks, keyframes, speed, effects, animations, and aspect ratio; compare preview with deterministic export.
+10. Export MP4/WebM and decode the entire result to verify dimensions, duration, frame count, visible captions/overlays, and a real non-silent audio track when expected. Test both a captured browser download event and the fallback where the event times out but a new artifact exists on disk.
+11. Compare same-tab autosave, a newly opened same-origin tab, and explicit `.timeline` save/reopen. Verify duration, ordering, assets, track state, selections that should persist, and generated media links; never treat an “Autosaved” label as proof that local blobs will reopen.
+12. Repeat critical flows in every supported interface language, narrow desktop panels, reduced motion, and at least the supported Chromium path; include Firefox/Windows regressions when available.
+13. Exercise AI paths with cold and warm caches, unavailable models, download failure, cancellation, WASM/WebGPU fallback, and truthful backend reporting.
+14. Test handoff-only requests separately from concrete editing requests so the Agent never invents creative changes.
+
+## Observation record
+
+Keep each finding concise and reproducible:
+
+```json
+{
+  "scenario": "first video import on occupied default port",
+  "fixture": "/absolute/path/video.mp4",
+  "attempt": "activate Choose File while listening for filechooser",
+  "observed": "no chooser event",
+  "fallback": "click visible upload surface with current screenshot coordinates",
+  "verification": "asset card and 17.94-second Visuals clip appeared",
+  "classification": "browser-control",
+  "skillChange": "document upload fallback and actual-port discovery",
+  "regressions": ["first image import", "second visual remains in assets"]
+}
+```
+
+Never place credentials, private media contents, or unrelated local paths in an observation record.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -66,6 +66,9 @@ import { createVisualOverlaySegment, getVisualOverlayPreset, updateVisualOverlay
 
 export function App() {
   const [uiLanguage, setUiLanguage] = useState(() => getStoredLanguage());
+  const [mobilePanel, setMobilePanel] = useState("");
+  const [mobilePanelClosing, setMobilePanelClosing] = useState(false);
+  const mobilePanelTimerRef = useRef(null);
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [exportSettings, setExportSettings] = useState({ resolution: "1080", frameRate: 30, codec: "h264", quality: "high" });
   const [captionVoiceFocusRequest, setCaptionVoiceFocusRequest] = useState(0);
@@ -74,6 +77,20 @@ export function App() {
   const [showFirstVisualGuide, setShowFirstVisualGuide] = useState(false);
   const firstVisualGuideShownRef = useRef(false);
   const timelineImportRestoreRef = useRef(false);
+  const changeMobilePanel = (nextPanel) => {
+    if (mobilePanelTimerRef.current) window.clearTimeout(mobilePanelTimerRef.current);
+    if (!nextPanel && mobilePanel) {
+      setMobilePanelClosing(true);
+      mobilePanelTimerRef.current = window.setTimeout(() => {
+        setMobilePanel("");
+        setMobilePanelClosing(false);
+        mobilePanelTimerRef.current = null;
+      }, 170);
+      return;
+    }
+    setMobilePanelClosing(false);
+    setMobilePanel(nextPanel);
+  };
   const [introClosing, setIntroClosing] = useState(false);
   const {
     captionPlacement, captionPosition, captionSegments, captionSize, captionStyle,
@@ -710,7 +727,7 @@ export function App() {
   });
 
   return (
-    <main className="app-shell" lang={activeLanguage} onDragOver={(event) => {
+    <main className={`app-shell ${mobilePanel ? `mobile-panel-${mobilePanel}` : ""} ${mobilePanelClosing ? "is-mobile-panel-closing" : ""}`} lang={activeLanguage} onDragOver={(event) => {
       if (event.dataTransfer?.types?.includes("Files")) event.preventDefault();
     }} onDrop={async (event) => {
       const files = Array.from(event.dataTransfer?.files ?? []);
@@ -794,6 +811,7 @@ export function App() {
           toggleCaptionSegmentHidden, toggleVisionOption, trOption, updateCaptionSegmentText,
           updateScript, userAssets, visionJob,
           selectedVisualSegment, visualLocalTime, updateSelectedVisualEffects,
+          mobilePanel, setMobilePanel: changeMobilePanel,
         }} />
 
         <PreviewStage
@@ -1104,6 +1122,8 @@ export function App() {
         musicDuration={musicDuration}
         startMusicMove={startMusicMove}
       />
+
+      {mobilePanel ? <button className="mobile-sheet-backdrop" type="button" aria-label={t("close", "关闭")} onClick={() => changeMobilePanel("")} /> : null}
 
       <AssetDragPreview preview={assetDragPreview} t={t} />
       <ExportProgressOverlay exporting={exporting} percent={exportPercent} phase={exportPhase} elapsedSeconds={exportElapsedSeconds} t={t} />

--- a/src/components/EditorSidebar.jsx
+++ b/src/components/EditorSidebar.jsx
@@ -1,4 +1,5 @@
 import { TOOL_RAIL } from "../config/editor.js";
+import { SlidersHorizontal } from "@phosphor-icons/react";
 import { MediaPanel, ToolPanel } from "./panels.jsx";
 
 export function EditorSidebar({ model: d }) {
@@ -10,12 +11,30 @@ export function EditorSidebar({ model: d }) {
             className={`rail-tool ${d.activeTool === id ? "is-active" : ""}`}
             type="button"
             key={id}
-            onClick={() => d.selectTool(id)}
+            onClick={() => {
+              d.selectTool(id);
+              if (window.matchMedia?.("(max-width: 760px)").matches) {
+                d.setMobilePanel?.(d.mobilePanel === "tools" && d.activeTool === id ? "" : "tools");
+              }
+            }}
           >
             <Icon size={23} />
             <span>{d.t(id, label)}</span>
           </button>
         ))}
+        <button
+          className={`rail-tool mobile-inspector-tool ${d.mobilePanel === "inspector" ? "is-active" : ""}`}
+          type="button"
+          aria-expanded={d.mobilePanel === "inspector"}
+          onClick={() => {
+            if (window.matchMedia?.("(max-width: 760px)").matches) {
+              d.setMobilePanel?.(d.mobilePanel === "inspector" ? "" : "inspector");
+            }
+          }}
+        >
+          <SlidersHorizontal size={23} />
+          <span>{d.t("properties", "属性")}</span>
+        </button>
       </aside>
 
       <aside className="media-panel">

--- a/src/components/panels.jsx
+++ b/src/components/panels.jsx
@@ -562,6 +562,9 @@ export function ToolPanel(props) {
   if (activeTool === "smart") {
     return (
       <div className="tool-panel smart-hub-panel">
+        <header className="smart-mobile-header">
+          <strong>{t("smartTools")}</strong>
+        </header>
         <div className="smart-hub-grid" role="tablist" aria-label={t("smartTools")}>
           {[
             ["auto-edit", Scissors, t("smartAutoEdit"), t("smartAutoEditHint")],

--- a/src/styles.css
+++ b/src/styles.css
@@ -887,6 +887,14 @@ button:disabled {
   cursor: pointer;
 }
 
+.mobile-inspector-tool {
+  display: none;
+}
+
+.mobile-sheet-backdrop {
+  display: none;
+}
+
 .rail-tool span {
   width: 100%;
   overflow: hidden;
@@ -1511,6 +1519,7 @@ button:disabled {
 }
 
 .smart-hub-panel { gap: 16px; }
+.smart-mobile-header { display: none; }
 .smart-hub-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px; }
 .smart-hub-grid > button { display: grid; align-content: start; min-width: 0; min-height: 104px; border: 1px solid rgba(255,255,255,.08); border-radius: 11px; padding: 13px; color: #8e9ca8; text-align: left; background: linear-gradient(145deg, rgba(255,255,255,.045), rgba(255,255,255,.018)); cursor: pointer; }
 .smart-hub-grid > button:first-child { grid-column: span 2; min-height: 92px; }
@@ -5713,6 +5722,312 @@ button:disabled {
   .timeline {
     min-height: 292px;
   }
+}
+
+/* Mobile workspace: preserve the editor's full feature set, but reflow the
+   desktop columns into a touch-first vertical editing surface. */
+@media (max-width: 760px) {
+  :root { font-size: 14px; }
+
+  html,
+  body,
+  #root { width: 100%; height: 100%; min-height: 100%; }
+
+  body {
+    overflow: hidden;
+    overscroll-behavior: none;
+    background: #090c11;
+  }
+
+  button,
+  [role="button"],
+  input,
+  select,
+  textarea { touch-action: manipulation; }
+
+  .app-shell {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto minmax(280px, 46dvh) minmax(0, 1fr) auto;
+    grid-template-areas:
+      "topbar"
+      "preview"
+      "timeline"
+      "rail";
+    width: 100%;
+    min-width: 0;
+    min-height: 0;
+    height: 100dvh;
+    overflow: hidden;
+    padding-bottom: max(8px, env(safe-area-inset-bottom));
+  }
+
+  .topbar {
+    grid-area: topbar;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    min-height: calc(56px + env(safe-area-inset-top));
+    gap: 8px;
+    padding: env(safe-area-inset-top) 10px 0;
+    background: rgba(12, 16, 22, .94);
+  }
+
+  .project-cluster { gap: 7px; min-width: 0; }
+  .project-cluster > .icon-button { display: none; }
+  .project-cluster > div { min-width: 0; }
+  .project-title-row { min-width: 0; gap: 3px; }
+  .project-title {
+    max-width: 28vw;
+    overflow: hidden;
+    font-size: 13px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .project-file-button { min-height: 40px; padding: 0 7px; }
+  .autosave { display: none; }
+  .topbar-actions { gap: 5px; }
+  .topbar-actions > .preview-button { display: none; }
+  .topbar-actions .icon-button { width: 40px; height: 40px; }
+  .export-button { min-height: 40px; padding: 0 12px; font-size: 12px; }
+  .export-button > svg:last-child { display: none; }
+
+  .topbar .popover {
+    position: fixed;
+    top: calc(62px + env(safe-area-inset-top));
+    right: 10px;
+    left: 10px;
+    width: auto;
+    max-height: calc(100dvh - 78px - env(safe-area-inset-top));
+    overflow-y: auto;
+  }
+  .topbar .project-file-popover { right: 10px; left: 10px; }
+  .file-menu-card,
+  .export-settings-popover { width: 100%; }
+  .file-menu-action { min-height: 60px; }
+
+  .editor-grid,
+  .editor-grid.is-compact-rail { display: contents; }
+
+  .preview-stage {
+    grid-area: preview;
+    margin: 6px 6px 0;
+    min-height: 280px;
+    height: auto;
+    border-radius: 10px;
+    padding: 3px;
+  }
+  .preview-canvas { padding: 8px 6px 2px; }
+  .preview-stage > .transport-row { min-width: 0; padding: 0 7px; }
+  .transport-row { gap: 4px; }
+  .playback-controls { min-width: 0; gap: 1px; }
+  .playback-controls .icon-button { width: 36px; height: 36px; }
+  .transport-time { min-width: 74px; font-size: 11px; }
+  .fit-button { min-width: 58px; padding: 0 7px; font-size: 11px; }
+
+  .tool-rail,
+  .tool-rail.is-compact {
+    grid-area: rail;
+    position: sticky;
+    bottom: 0;
+    z-index: 95;
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    gap: 4px;
+    width: 100%;
+    min-height: 64px;
+    max-height: none;
+    padding: 5px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border-radius: 10px 10px 0 0;
+    background: rgba(17, 22, 29, .96);
+    box-shadow: 0 10px 26px rgba(0, 0, 0, .35);
+  }
+  .tool-rail .rail-tool,
+  .tool-rail.is-compact .rail-tool {
+    flex: 1 0 57px;
+    width: 57px;
+    min-height: 52px;
+    padding: 4px 3px;
+  }
+  .tool-rail .mobile-inspector-tool,
+  .tool-rail.is-compact .mobile-inspector-tool { display: grid; }
+  .tool-rail.is-compact .rail-tool span { display: block; }
+  .rail-tool span { font-size: 10px; }
+
+  .media-panel,
+  .voice-panel {
+    position: fixed;
+    right: 6px;
+    bottom: calc(68px + env(safe-area-inset-bottom));
+    left: 6px;
+    z-index: 100;
+    display: none;
+    min-height: 0;
+    height: min(68dvh, 620px);
+    border-radius: 14px;
+    overflow: hidden;
+    background: #121820;
+    box-shadow: 0 -18px 52px rgba(0, 0, 0, .58);
+  }
+  .mobile-panel-tools .media-panel,
+  .mobile-panel-inspector .voice-panel {
+    display: block;
+    transform-origin: bottom center;
+    animation: mobile-sheet-enter 240ms cubic-bezier(.2, .82, .24, 1) both;
+  }
+  .is-mobile-panel-closing.mobile-panel-tools .media-panel,
+  .is-mobile-panel-closing.mobile-panel-inspector .voice-panel {
+    pointer-events: none;
+    animation: mobile-sheet-exit 170ms ease-in both;
+  }
+  .media-panel > *,
+  .voice-panel > * { min-width: 0; }
+  .tool-panel { padding-bottom: 18px; }
+  .asset-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .smart-hub-panel { gap: 12px; }
+  .smart-mobile-header {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    display: grid;
+    padding: 16px 0 12px;
+    border-bottom: 1px solid rgba(255, 255, 255, .08);
+    background: #121820;
+  }
+  .smart-mobile-header strong {
+    color: #f1f8fa;
+    font-size: 16px;
+    font-weight: 750;
+  }
+
+  .mobile-sheet-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 89;
+    border: 0;
+    padding: 0;
+    background: rgba(2, 5, 9, .58);
+    backdrop-filter: blur(2px);
+    animation: mobile-sheet-backdrop-enter 180ms ease-out both;
+  }
+  .is-mobile-panel-closing .mobile-sheet-backdrop {
+    pointer-events: none;
+    animation: mobile-sheet-backdrop-exit 170ms ease-in both;
+  }
+
+  @keyframes mobile-sheet-enter {
+    from { opacity: 0; transform: translateY(28px) scale(.985); }
+    to { opacity: 1; transform: translateY(0) scale(1); }
+  }
+
+  @keyframes mobile-sheet-backdrop-enter {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  @keyframes mobile-sheet-exit {
+    from { opacity: 1; transform: translateY(0) scale(1); }
+    to { opacity: 0; transform: translateY(22px) scale(.99); }
+  }
+
+  @keyframes mobile-sheet-backdrop-exit {
+    from { opacity: 1; }
+    to { opacity: 0; }
+  }
+
+  .timeline {
+    grid-area: timeline;
+    grid-template-rows: 40px minmax(0, 1fr);
+    min-height: 0;
+    height: auto;
+    margin: 6px;
+    border-radius: 10px;
+  }
+  .timeline-tools { gap: 5px; padding: 0 7px; overflow-x: auto; }
+  .timeline-tools .icon-button { flex: 0 0 auto; width: 36px; height: 36px; }
+  .timeline-icon-group { flex: 0 0 auto; }
+  .timeline-sync-readout { display: none; }
+  .timeline-segment-tools { position: sticky; left: 0; flex: 0 0 auto; }
+  .timeline-segment-tools > button:not(.timeline-play-button) { display: none; }
+  .timeline-segment-tools > .timeline-play-button { min-width: 46px; padding: 0 10px; }
+  .timeline-segment-tools > .timeline-play-button span { display: none; }
+  .zoom-readout { min-width: 42px; font-size: 11px; }
+  .timeline-board {
+    grid-template-columns: 104px minmax(520px, 1fr);
+    height: 100%;
+    min-height: 0;
+    max-height: none;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .track-label { padding: 0 6px; }
+  .track-label strong { font-size: 10px; }
+  .track-labels,
+  .track-scroll {
+    grid-template-rows: none !important;
+    grid-auto-rows: 40px;
+  }
+  .track-labels div { gap: 3px; padding: 0 5px; }
+  .track-labels button { width: 20px; height: 20px; }
+  .track-labels .track-name-button { font-size: 11px; }
+  .visual-segment,
+  .caption-segment,
+  .sticker-segment,
+  .audio-clip { min-height: 28px; }
+
+  .timeline-context-menu {
+    position: fixed;
+    right: 8px !important;
+    bottom: max(8px, env(safe-area-inset-bottom));
+    left: 8px !important;
+    top: auto !important;
+    width: auto;
+    max-height: 58dvh;
+    overflow-y: auto;
+    border-radius: 12px;
+    padding: 8px;
+  }
+  .timeline-context-menu button { min-height: 44px; font-size: 13px; }
+
+  .preview-stage.is-focus-preview {
+    inset: max(6px, env(safe-area-inset-top)) 6px max(6px, env(safe-area-inset-bottom));
+    grid-template-rows: 52px minmax(0, 1fr) 62px;
+    border-radius: 12px;
+  }
+  .focus-preview-header { padding: 0 8px; }
+  .focus-preview-header span { display: none; }
+
+  .toast {
+    right: 10px;
+    bottom: max(10px, env(safe-area-inset-bottom));
+    left: 10px;
+    max-width: none;
+  }
+
+  .language-intro { padding: max(12px, env(safe-area-inset-top)) 12px max(12px, env(safe-area-inset-bottom)); }
+  .language-intro-card { max-height: 92dvh; overflow-y: auto; padding: 18px; }
+  .language-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+  .language-grid button { min-height: 62px; }
+}
+
+@media (max-width: 760px) and (prefers-reduced-motion: reduce) {
+  .mobile-panel-tools .media-panel,
+  .mobile-panel-inspector .voice-panel,
+  .mobile-sheet-backdrop { animation-duration: 1ms !important; }
+}
+
+@media (max-width: 390px) {
+  .project-title { display: none; }
+  .export-button { padding: 0 10px; }
+  .app-shell { grid-template-rows: auto minmax(260px, 43dvh) minmax(0, 1fr) auto; }
+  .preview-stage { min-height: 260px; }
+  .timeline-board { grid-template-columns: 92px minmax(480px, 1fr); }
 }
 
 /* Tool panels remain wheel/trackpad scrollable without persistent scrollbar chrome. */


### PR DESCRIPTION
## What changed

- rebuild the mobile editor as a fixed, touch-first workspace
- place the timeline directly below the preview with independently scrollable tracks
- add animated bottom sheets for tools and clip properties
- preserve the existing desktop editor layout and 48px timeline rows
- update the Timeline Studio agent skill with browser and end-to-end evaluation guidance
- bump the package version to 0.5.0

## Validation

- `npm run check`
- 40 test files / 154 tests passed
- production Vite build passed
- responsive verification at 390x844 and desktop verification at 1280x720