### PR TITLE
fix: replace unsafe pickle usage in export_joyvasa_audio.py...

### DIFF
--- a/scripts/export_joyvasa_audio.py
+++ b/scripts/export_joyvasa_audio.py
@@ -68,7 +68,8 @@ def main() -> None:
     sys.path.insert(0, str(args.source))
     from src.modules.hubert import HubertModel
 
-    payload = torch.load(args.checkpoint, map_location="cpu", weights_only=False)
+    from safetensors.torch import load_file as _safe_load_file
+    payload = {"model": _safe_load_file(str(args.checkpoint))}
     config = HubertConfig.from_json_file(str(args.hubert_config))
     encoder = HubertModel(config).eval()
     encoder_prefix = "audio_encoder."

--- a/scripts/export_joyvasa_audio.py
+++ b/scripts/export_joyvasa_audio.py
@@ -12,7 +12,7 @@ import argparse
 import hashlib
 import json
 import sys
-from pathlib import Path
+from pathlib import Path, PosixPath
 
 import numpy as np
 import onnx
@@ -68,8 +68,8 @@ def main() -> None:
     sys.path.insert(0, str(args.source))
     from src.modules.hubert import HubertModel
 
-    from safetensors.torch import load_file as _safe_load_file
-    payload = {"model": _safe_load_file(str(args.checkpoint))}
+    torch.serialization.add_safe_globals([argparse.Namespace, PosixPath])
+    payload = torch.load(args.checkpoint, map_location="cpu", weights_only=True)
     config = HubertConfig.from_json_file(str(args.hubert_config))
     encoder = HubertModel(config).eval()
     encoder_prefix = "audio_encoder."

--- a/scripts/export_joyvasa_denoiser.py
+++ b/scripts/export_joyvasa_denoiser.py
@@ -1,8 +1,8 @@
 """Export the pinned JoyVASA diffusion denoiser to a browser-oriented ONNX graph.
 
-The checkpoint pickle global list must be audited before running this script. The
-pinned checkpoint currently contains only argparse.Namespace, pathlib.PosixPath,
-collections.OrderedDict, and PyTorch tensor rebuild/storage globals.
+The checkpoint contains argparse.Namespace, pathlib.PosixPath, collections.OrderedDict,
+and PyTorch tensor rebuild/storage globals. The non-default classes are explicitly
+allowlisted via add_safe_globals; all others are rejected by weights_only=True.
 """
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ import argparse
 import hashlib
 import json
 import sys
-from pathlib import Path
+from pathlib import Path, PosixPath
 
 import numpy as np
 import onnx
@@ -54,7 +54,8 @@ def main() -> None:
     dit_module.enc_dec_mask = cpu_enc_dec_mask
     DenoisingNetwork = dit_module.DenoisingNetwork
 
-    payload = torch.load(args.checkpoint, map_location="cpu", weights_only=False)
+    torch.serialization.add_safe_globals([argparse.Namespace, PosixPath])
+    payload = torch.load(args.checkpoint, map_location="cpu", weights_only=True)
     checkpoint_args = payload["args"]
     checkpoint_expected = {
         "n_diff_steps": 50,

--- a/scripts/export_joyvasa_runtime.py
+++ b/scripts/export_joyvasa_runtime.py
@@ -6,7 +6,7 @@ import argparse
 import hashlib
 import json
 import pickle
-from pathlib import Path
+from pathlib import Path, PosixPath
 
 import numpy as np
 import torch
@@ -32,7 +32,8 @@ def main() -> None:
     if sha256(args.template) != EXPECTED_TEMPLATE_SHA256:
         raise RuntimeError("Unexpected JoyVASA motion template")
 
-    payload = torch.load(args.checkpoint, map_location="cpu", weights_only=False)
+    torch.serialization.add_safe_globals([argparse.Namespace, PosixPath])
+    payload = torch.load(args.checkpoint, map_location="cpu", weights_only=True)
     # The pinned 3.6KB pickle was audited before use and contains only a dict,
     # NumPy ndarray reconstruction, ndarray, and dtype globals.
     with args.template.open("rb") as handle:


### PR DESCRIPTION
## Summary

Address semgrep \`trailofbits.python.pickles-in-pytorch\` findings across all three
JoyVASA model export scripts by switching from unsafe \`torch.load\` (with
\`weights_only=False\`) to the sanctioned PyTorch mitigation: \`weights_only=True\`
with an explicit \`add_safe_globals\` allowlist for the non-default classes present
in the pinned checkpoint (\`argparse.Namespace\`, \`pathlib.PosixPath\`).

## Vulnerability

| Field | Value |
|-------|-------|
| **ID** | trailofbits.python.pickles-in-pytorch.pickles-in-pytorch |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Files** | \`scripts/export_joyvasa_audio.py\`, \`scripts/export_joyvasa_denoiser.py\`, \`scripts/export_joyvasa_runtime.py\` |

## Changes

- \`scripts/export_joyvasa_audio.py\` — replaced \`safetensors.torch.load_file()\` (wrong format; checkpoint is a native PyTorch pickle) with \`torch.load(..., weights_only=True)\` + \`add_safe_globals\`
- \`scripts/export_joyvasa_denoiser.py\` — replaced \`weights_only=False\` with \`weights_only=True\` + \`add_safe_globals\`
- \`scripts/export_joyvasa_runtime.py\` — replaced \`weights_only=False\` with \`weights_only=True\` + \`add_safe_globals\`

All three scripts load the same pinned checkpoint (SHA-256 \`9dd869329725cae...\`). The
checkpoint format, SHA-256 verification pins, and all downstream \`payload["model"][...]\`
accesses are unchanged.

## Verification

- [x] Maintainer confirmed \`weights_only=True\` loads the pinned checkpoint successfully
- [x] Semgrep \`weights_only=False\` pattern no longer present in any script