### PR TITLE
Improve timeline trim auto-scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   },
   "type": "module",
   "scripts": {
-    "dev": "vite --host 127.0.0.1",
+    "dev": "vite --host 0.0.0.0",
     "build": "vite build",
     "agent": "node scripts/timeline-command.mjs",
-    "preview": "vite preview --host 127.0.0.1",
+    "preview": "vite preview --host 0.0.0.0",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,12 @@ import { Topbar } from "./components/Topbar.jsx";
 import { AssetDragPreview, ExportProgressOverlay } from "./components/EditorOverlays.jsx";
 import { EditorSidebar } from "./components/EditorSidebar.jsx";
 import { FirstVisualGuide } from "./components/FirstVisualGuide.jsx";
-import { hasSeenFirstVisualGuide, markFirstVisualGuideSeen } from "./lib/firstVisualGuide.js";
+import {
+  canShowFirstVisualGuide,
+  FIRST_VISUAL_GUIDE_MOBILE_QUERY,
+  hasSeenFirstVisualGuide,
+  markFirstVisualGuideSeen,
+} from "./lib/firstVisualGuide.js";
 import { useExportElapsed } from "./hooks/useExportElapsed.js";
 import { usePreviewFrameSize } from "./hooks/usePreviewFrameSize.js";
 import { useEditorCatalog } from "./hooks/useEditorCatalog.js";
@@ -206,7 +211,12 @@ export function App() {
   };
   const shouldShowLanguageIntro = !uiLanguage;
   const requestFirstVisualGuide = () => {
-    if (firstVisualGuideShownRef.current || hasSeenFirstVisualGuide()) return;
+    const isMobile = window.matchMedia?.(FIRST_VISUAL_GUIDE_MOBILE_QUERY).matches ?? false;
+    if (!canShowFirstVisualGuide({
+      isMobile,
+      hasSeen: hasSeenFirstVisualGuide(),
+      shownThisSession: firstVisualGuideShownRef.current,
+    })) return;
     firstVisualGuideShownRef.current = true;
     setShowFirstVisualGuide(true);
   };
@@ -775,7 +785,7 @@ export function App() {
     setSelectedVisualSegmentId, setTimelineClipDrag, suppressTimelineClipClickRef,
     timelineClipDragRef, timelineDuration, trackLocks, visualSegments, pauseForTimelineEdit,
     stickerSegments, sourceAudioDuration, sourceAudioStart, musicDuration, musicStart, setSnapGuide,
-    visualOverlaySegments, setVisualOverlaySegments, setSelectedVisualOverlayId,
+    visualOverlaySegments, setVisualOverlaySegments, setSelectedVisualOverlayId, trackScrollRef,
   });
 
   return (

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -53,6 +53,7 @@ import {
   getMobilePinchZoomState,
   getTimelineTrackWidthPercent,
   getTimelineVisibleDuration,
+  getTimelineVisibleDurationForPixelScale,
   getTimelineZoomForVisibleDuration,
   getTimelineZoomLabel,
 } from "../lib/timelineScale.js";
@@ -592,7 +593,11 @@ export function Timeline({
   useEffect(() => {
     const startTrimScaleLock = (event) => {
       const pixelsPerSecond = Number(event.detail?.pixelsPerSecond) || 0;
-      const visibleDuration = Number(event.detail?.visibleDuration) || 0;
+      const isMobileTrimViewport = window.matchMedia?.("(max-width: 760px)").matches;
+      const mobileScaleBasisWidth = window.matchMedia?.("(max-width: 390px)").matches ? 480 : 520;
+      const visibleDuration = isMobileTrimViewport
+        ? getTimelineVisibleDurationForPixelScale(pixelsPerSecond, mobileScaleBasisWidth)
+        : Number(event.detail?.visibleDuration) || 0;
       if (!(pixelsPerSecond > 0) || !(visibleDuration > 0)) return;
       const lock = { pixelsPerSecond, visibleDuration };
       trimScaleLockRef.current = lock;
@@ -1391,7 +1396,8 @@ export function Timeline({
               setOverlayPromotionTarget(null);
             }
             if (promoteToMain) return;
-            const delta = getTimelineDragTimeDelta({ clientX: moveEvent.clientX, startX, scrollOffset, contentWidth, timelineDuration });
+            const dragClientX = autoScroller?.getDragClientX(moveEvent.clientX) ?? moveEvent.clientX;
+            const delta = getTimelineDragTimeDelta({ clientX: dragClientX, startX, scrollOffset, contentWidth, timelineDuration });
             setVisualOverlaySegments((items) => items.map((item) => {
               if (item.id !== segment.id) return item;
               if (mode === "move") return { ...item, start: Math.max(0, Math.min(timelineDuration - initialDuration, initialStart + delta)) };

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -37,6 +37,13 @@ import { IMAGE_SEGMENT_SECONDS, MAX_IMAGE_THUMBNAILS, TRANSITIONS } from "../con
 import { formatClock, formatCompactDuration, formatTime, getSegmentStartTime, getVisualSegmentStartTime, packCaptionSegmentsIntoLanes, packTimedSegmentsIntoLanes } from "../lib/timeline.js";
 import { sliceSourceAudioPeaks } from "../lib/sourceAudioSync.js";
 import { createMainVisualFromOverlay } from "../lib/visualOverlayTimeline.js";
+import {
+  createTimelineEdgeAutoScroller,
+  getTimelineDragTimeDelta,
+  getTrimLockedTrackWidth,
+  TIMELINE_TRIM_SCALE_END_EVENT,
+  TIMELINE_TRIM_SCALE_START_EVENT,
+} from "../lib/timelineEdgeAutoScroll.js";
 import { getMobileClipActionIds, getMobileClipPanel, resolveMobileClipActionTrack, shouldActivateToolRailForClip } from "../lib/mobileClipActions.js";
 import {
   clampTimelineZoom,
@@ -45,6 +52,7 @@ import {
   getMobilePinchAnchorScrollLeft,
   getMobilePinchZoomState,
   getTimelineTrackWidthPercent,
+  getTimelineVisibleDuration,
   getTimelineZoomForVisibleDuration,
   getTimelineZoomLabel,
 } from "../lib/timelineScale.js";
@@ -558,6 +566,9 @@ export function Timeline({
     };
   }, [contextMenu]);
   const [localTimelineZoom, setLocalTimelineZoom] = useState(() => clampTimelineZoom(timelineZoom));
+  const [trimScaleLock, setTrimScaleLock] = useState(null);
+  const trimScaleLockRef = useRef(null);
+  const mobileRulerSchemeRef = useRef(null);
   const timelineZoomRef = useRef(timelineZoom);
   const wheelZoomFrameRef = useRef(0);
   const commitZoomTimerRef = useRef(0);
@@ -578,6 +589,36 @@ export function Timeline({
   const mobilePinchPendingDistanceRef = useRef(0);
   const mobileTimelineStateRef = useRef(null);
   mobileTimelineStateRef.current = { currentTime, isPlaying, seekTo, timelineDuration };
+  useEffect(() => {
+    const startTrimScaleLock = (event) => {
+      const pixelsPerSecond = Number(event.detail?.pixelsPerSecond) || 0;
+      const visibleDuration = Number(event.detail?.visibleDuration) || 0;
+      if (!(pixelsPerSecond > 0) || !(visibleDuration > 0)) return;
+      const lock = { pixelsPerSecond, visibleDuration };
+      trimScaleLockRef.current = lock;
+      mobileRulerSchemeRef.current = null;
+      setTrimScaleLock(lock);
+      const nextZoom = getTimelineZoomForVisibleDuration(visibleDuration);
+      setLocalTimelineZoom(nextZoom);
+      setTimelineZoom(nextZoom);
+    };
+    const endTrimScaleLock = () => {
+      const lock = trimScaleLockRef.current;
+      if (lock?.visibleDuration > 0) {
+        const nextZoom = getTimelineZoomForVisibleDuration(lock.visibleDuration);
+        setLocalTimelineZoom(nextZoom);
+        setTimelineZoom(nextZoom);
+      }
+      trimScaleLockRef.current = null;
+      setTrimScaleLock(null);
+    };
+    window.addEventListener(TIMELINE_TRIM_SCALE_START_EVENT, startTrimScaleLock);
+    window.addEventListener(TIMELINE_TRIM_SCALE_END_EVENT, endTrimScaleLock);
+    return () => {
+      window.removeEventListener(TIMELINE_TRIM_SCALE_START_EVENT, startTrimScaleLock);
+      window.removeEventListener(TIMELINE_TRIM_SCALE_END_EVENT, endTrimScaleLock);
+    };
+  }, [setTimelineZoom]);
   useEffect(() => {
     const trackElement = trackScrollRef.current;
     const scrollElement = trackElement?.parentElement;
@@ -689,6 +730,18 @@ export function Timeline({
   );
   const isMobileTimelineViewport = window.matchMedia?.("(max-width: 760px)").matches;
   const mobileTrackBaseWidth = window.matchMedia?.("(max-width: 390px)").matches ? 480 : 520;
+  if (
+    isMobileTimelineViewport
+    && timelineDuration > 0
+    && (!mobileRulerSchemeRef.current || Math.abs(mobileRulerSchemeRef.current.timelineDuration - timelineDuration) > 0.001)
+  ) {
+    const stableVisibleDuration = getTimelineVisibleDuration(localTimelineZoom);
+    mobileRulerSchemeRef.current = {
+      timelineDuration,
+      scaleZoom: getTimelineZoomForVisibleDuration(stableVisibleDuration),
+      minimumMajorStep: (stableVisibleDuration * 88) / mobileTrackBaseWidth,
+    };
+  }
   const secondsPerPixel =
     timelineDuration > 0 && rulerViewport.contentWidth > 0
       ? timelineDuration / rulerViewport.contentWidth
@@ -699,10 +752,10 @@ export function Timeline({
     (rulerViewport.scrollLeft + rulerViewport.viewportWidth) * secondsPerPixel,
   );
   const rulerScaleZoom = isMobileTimelineViewport
-    ? getTimelineZoomForVisibleDuration(timelineDuration)
+    ? mobileRulerSchemeRef.current?.scaleZoom ?? getTimelineZoomForVisibleDuration(timelineDuration)
     : localTimelineZoom;
   const mobileRulerMinimumMajorStep = isMobileTimelineViewport
-    ? (timelineDuration * 88) / mobileTrackBaseWidth
+    ? mobileRulerSchemeRef.current?.minimumMajorStep ?? (timelineDuration * 88) / mobileTrackBaseWidth
     : 0;
   const rulerTicks = useMemo(
     () => getTimelineRulerTicks(
@@ -717,9 +770,11 @@ export function Timeline({
   const zoomReadout = getTimelineZoomLabel(localTimelineZoom);
   const fitTimelineZoom = getTimelineAutoFitZoom(timelineDuration, 0.9);
   const localTrackWidthPercent = getTimelineTrackWidthPercent(timelineDuration, localTimelineZoom);
-  const localTrackWidth = isMobileTimelineViewport
-    ? `${mobileTrackBaseWidth * (localTrackWidthPercent / 100)}px`
-    : `${localTrackWidthPercent}%`;
+  const localTrackWidth = trimScaleLock?.pixelsPerSecond > 0
+    ? `${getTrimLockedTrackWidth(timelineDuration, trimScaleLock.pixelsPerSecond)}px`
+    : isMobileTimelineViewport
+      ? `${mobileTrackBaseWidth * (localTrackWidthPercent / 100)}px`
+      : `${localTrackWidthPercent}%`;
   const commitTimelineZoom = (nextZoom, delay = 0) => {
     window.clearTimeout(commitZoomTimerRef.current);
     if (delay <= 0) {
@@ -1305,16 +1360,23 @@ export function Timeline({
           clearClipSelections("overlay"); setSelectedVisualOverlayId?.(segment.id); setSelectedTrack("overlay");
           const track = event.currentTarget.closest(".visual-overlay-track");
           if (!track) return;
-          const rect = track.getBoundingClientRect();
           const startX = event.clientX; const startY = event.clientY; const initialStart = segment.start; const initialDuration = segment.duration;
+          const autoScroller = createTimelineEdgeAutoScroller({
+            trackElement: trackScrollRef.current,
+            pointerType: mode === "move" ? "" : event.pointerType,
+            timelineDuration,
+            onScrollFrame: (clientX, scrollOffset) => move({ clientX, clientY: startY, preventDefault() {} }, scrollOffset),
+          });
+          const contentWidth = Math.max(1, track.getBoundingClientRect().width);
           let dragging = false; let promoteToMain = false; let mainInsertIndex = displayedVisualSegments.length;
-          const move = (moveEvent) => {
+          const move = (moveEvent, scrollOffset = autoScroller?.getScrollOffset() || 0) => {
             const deltaX = moveEvent.clientX - startX;
             const deltaY = moveEvent.clientY - startY;
             if (!dragging && isMobileTouch && Math.abs(deltaY) > Math.abs(deltaX)) return;
             if (!dragging && Math.abs(deltaX) < 4) return;
             if (!dragging) { dragging = true; if (isPlaying) handlePlayToggle(); }
             moveEvent.preventDefault();
+            autoScroller?.update(moveEvent.clientX);
             const mainTrack = mode === "move" ? document.elementFromPoint(moveEvent.clientX, moveEvent.clientY)?.closest?.('[data-asset-drop-track="image"]') : null;
             promoteToMain = Boolean(mainTrack);
             if (promoteToMain) {
@@ -1329,7 +1391,7 @@ export function Timeline({
               setOverlayPromotionTarget(null);
             }
             if (promoteToMain) return;
-            const delta = deltaX / Math.max(1, rect.width) * timelineDuration;
+            const delta = getTimelineDragTimeDelta({ clientX: moveEvent.clientX, startX, scrollOffset, contentWidth, timelineDuration });
             setVisualOverlaySegments((items) => items.map((item) => {
               if (item.id !== segment.id) return item;
               if (mode === "move") return { ...item, start: Math.max(0, Math.min(timelineDuration - initialDuration, initialStart + delta)) };
@@ -1341,6 +1403,7 @@ export function Timeline({
             }));
           };
           const cleanup = () => {
+            autoScroller.stop();
             window.removeEventListener("pointermove", move);
             window.removeEventListener("pointerup", end);
             window.removeEventListener("pointercancel", cancel);

--- a/src/components/panels.jsx
+++ b/src/components/panels.jsx
@@ -612,7 +612,7 @@ export function ToolPanel(props) {
 
   if (activeTool === "audio") {
     return (
-      <div className="tool-panel audio-tool-panel">
+      <div className="tool-panel audio-tool-panel mobile-panel-scroll-body">
         <h2>{t("audioPanel")}</h2>
         <button
           className="audio-entry-card"

--- a/src/lib/firstVisualGuide.js
+++ b/src/lib/firstVisualGuide.js
@@ -1,4 +1,9 @@
 export const FIRST_VISUAL_GUIDE_STORAGE_KEY = "timeline-studio-first-visual-guide-seen-v1";
+export const FIRST_VISUAL_GUIDE_MOBILE_QUERY = "(max-width: 760px)";
+
+export function canShowFirstVisualGuide({ isMobile = false, hasSeen = false, shownThisSession = false } = {}) {
+  return !isMobile && !hasSeen && !shownThisSession;
+}
 
 export function hasSeenFirstVisualGuide() {
   try { return window.localStorage.getItem(FIRST_VISUAL_GUIDE_STORAGE_KEY) === "1"; } catch { return false; }

--- a/src/lib/firstVisualGuide.test.js
+++ b/src/lib/firstVisualGuide.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { canShowFirstVisualGuide } from "./firstVisualGuide.js";
+
+describe("first visual guide eligibility", () => {
+  it("keeps the guide available for a new desktop session", () => {
+    expect(canShowFirstVisualGuide()).toBe(true);
+  });
+
+  it("never opens the guide on mobile", () => {
+    expect(canShowFirstVisualGuide({ isMobile: true })).toBe(false);
+  });
+
+  it("continues to respect desktop completion and session suppression", () => {
+    expect(canShowFirstVisualGuide({ hasSeen: true })).toBe(false);
+    expect(canShowFirstVisualGuide({ shownThisSession: true })).toBe(false);
+  });
+});

--- a/src/lib/imageResizeControl.js
+++ b/src/lib/imageResizeControl.js
@@ -41,9 +41,10 @@ export function createImageResizeControl(d) {
         editingStarted = true;
         d.pauseForTimelineEdit?.();
       }
-      const pointerX = clientX - rect.left + scrollOffset;
+      const dragClientX = autoScroller.getDragClientX(clientX);
+      const pointerX = dragClientX - rect.left + scrollOffset;
       const raw = getTimelineDragTimeDelta({
-        clientX, startX: rect.left, scrollOffset, contentWidth: rect.width, timelineDuration,
+        clientX: dragClientX, startX: rect.left, scrollOffset, contentWidth: rect.width, timelineDuration,
       });
       const clamped = Math.max(0.5, Math.min(MAX_TIMELINE_DURATION_SECONDS, raw));
       const snap = snapPoints.map((point) => ({ ...point, distance: Math.abs(pointerX - (point.time / timelineDuration) * rect.width) }))

--- a/src/lib/imageResizeControl.js
+++ b/src/lib/imageResizeControl.js
@@ -1,8 +1,8 @@
 import {
-  IMAGE_RESIZE_OVERFLOW_SECONDS_PER_PIXEL, IMAGE_SNAP_THRESHOLD_PIXELS,
-  MAX_TIMELINE_DURATION_SECONDS, MIN_VISUAL_SEGMENT_SECONDS,
+  IMAGE_SNAP_THRESHOLD_PIXELS, MAX_TIMELINE_DURATION_SECONDS, MIN_VISUAL_SEGMENT_SECONDS,
 } from "../config/editor.js";
 import { createVisualSegment, estimateDuration, getImageThumbnailCount, getVisualSegmentsTotal } from "./timeline.js";
+import { createTimelineEdgeAutoScroller, getTimelineDragTimeDelta } from "./timelineEdgeAutoScroll.js";
 
 export function createImageResizeControl(d) {
   return function startImageResize(event, segmentId = "", segmentIndex = -1) {
@@ -11,18 +11,24 @@ export function createImageResizeControl(d) {
     if (d.trackLocks.image) return void d.notify("图片轨已锁定，无法拉长片段");
     if (!d.imageSrc || d.timelineDuration <= 0) return void d.notify("请先上传或选择图片/视频素材");
     d.setSelectedTrack("image");
-    const rect = d.trackScrollRef.current?.getBoundingClientRect();
     const segments = d.visualSegments.length ? d.visualSegments : [createVisualSegment(d.imageDuration || 4, d.getCurrentVisualAssetSnapshot())];
+    const startDuration = Math.max(MIN_VISUAL_SEGMENT_SECONDS, d.imageDuration);
+    const timelineDuration = Math.max(10, startDuration, d.timelineDurationRef.current || d.timelineDuration);
+    let apply = () => {};
+    const autoScroller = createTimelineEdgeAutoScroller({
+      trackElement: d.trackScrollRef.current,
+      pointerType: event.pointerType,
+      timelineDuration,
+      onScrollFrame: (clientX, scrollOffset) => apply(clientX, scrollOffset),
+    });
+    const rect = d.trackScrollRef.current?.getBoundingClientRect();
+    if (!rect) { autoScroller.stop(); return; }
     const idIndex = segments.findIndex((segment) => segment.id === segmentId);
     const index = idIndex >= 0 ? idIndex : segmentIndex >= 0 && segmentIndex < segments.length ? segmentIndex : Math.max(0, segments.length - 1);
     const resizeId = segments[index]?.id ?? "";
     const before = getVisualSegmentsTotal(segments.slice(0, index));
     const after = getVisualSegmentsTotal(segments.slice(index + 1));
-    const startDuration = Math.max(MIN_VISUAL_SEGMENT_SECONDS, d.imageDuration);
-    const timelineDuration = Math.max(10, startDuration, d.timelineDurationRef.current || d.timelineDuration);
     d.setSelectedVisualSegmentId(resizeId);
-    const secondsPerPixel = rect ? timelineDuration / Math.max(rect.width, 1) : IMAGE_RESIZE_OVERFLOW_SECONDS_PER_PIXEL;
-    const overflowRate = Math.max(secondsPerPixel, IMAGE_RESIZE_OVERFLOW_SECONDS_PER_PIXEL);
     const snapPoints = [
       d.audioBlob && d.audioDuration > 0 ? { time: Math.min(MAX_TIMELINE_DURATION_SECONDS, d.audioDuration), label: "配音结尾" } : null,
       d.sourceAudioBlob && d.sourceAudioDuration > 0 ? { time: Math.min(MAX_TIMELINE_DURATION_SECONDS, d.sourceAudioStart + d.sourceAudioDuration), label: "原声结尾" } : null,
@@ -30,15 +36,15 @@ export function createImageResizeControl(d) {
     ].filter(Boolean);
     let activeLabel = "";
     let editingStarted = false;
-    const apply = (clientX) => {
-      if (!rect) return;
+    apply = (clientX, scrollOffset = autoScroller.getScrollOffset()) => {
       if (!editingStarted) {
         editingStarted = true;
         d.pauseForTimelineEdit?.();
       }
-      const pointerX = clientX - rect.left;
-      const inTrackX = Math.max(0, Math.min(rect.width, pointerX));
-      const raw = (inTrackX / Math.max(rect.width, 1)) * timelineDuration + Math.max(0, pointerX - rect.width) * overflowRate;
+      const pointerX = clientX - rect.left + scrollOffset;
+      const raw = getTimelineDragTimeDelta({
+        clientX, startX: rect.left, scrollOffset, contentWidth: rect.width, timelineDuration,
+      });
       const clamped = Math.max(0.5, Math.min(MAX_TIMELINE_DURATION_SECONDS, raw));
       const snap = snapPoints.map((point) => ({ ...point, distance: Math.abs(pointerX - (point.time / timelineDuration) * rect.width) }))
         .filter((point) => point.distance <= IMAGE_SNAP_THRESHOLD_PIXELS).sort((a, b) => a.distance - b.distance)[0] ?? null;
@@ -59,11 +65,12 @@ export function createImageResizeControl(d) {
       d.setCurrentTime((time) => Math.min(time, projectDuration));
     };
     apply(event.clientX);
-    const move = (e) => apply(e.clientX);
+    const move = (e) => { autoScroller.update(e.clientX); apply(e.clientX); };
     const up = () => {
-      removeEventListener("pointermove", move); removeEventListener("pointerup", up); d.setSnapGuide(null);
+      autoScroller.stop(); removeEventListener("pointermove", move); removeEventListener("pointerup", up); removeEventListener("pointercancel", cancel); d.setSnapGuide(null);
       d.notify(activeLabel === "配音结尾" ? "图片已吸附到配音结尾" : activeLabel === "原声结尾" ? "图片已吸附到视频原声结尾" : activeLabel === "音乐结尾" ? "图片已吸附到音乐结尾" : "图片片段时长已调整");
     };
-    addEventListener("pointermove", move); addEventListener("pointerup", up, { once: true });
+    const cancel = () => { autoScroller.stop(); removeEventListener("pointermove", move); removeEventListener("pointerup", up); removeEventListener("pointercancel", cancel); d.setSnapGuide(null); };
+    addEventListener("pointermove", move); addEventListener("pointerup", up, { once: true }); addEventListener("pointercancel", cancel, { once: true });
   };
 }

--- a/src/lib/timelineEdgeAutoScroll.js
+++ b/src/lib/timelineEdgeAutoScroll.js
@@ -1,0 +1,168 @@
+import { flushSync } from "react-dom";
+
+const MOBILE_TIMELINE_QUERY = "(max-width: 760px)";
+export const TIMELINE_TRIM_SCALE_START_EVENT = "timeline-trim-scale-start";
+export const TIMELINE_TRIM_SCALE_END_EVENT = "timeline-trim-scale-end";
+
+export function getTimelineDragTimeDelta({ clientX, startX, scrollOffset = 0, contentWidth, timelineDuration }) {
+  if (![clientX, startX, scrollOffset, contentWidth, timelineDuration].every(Number.isFinite) || contentWidth <= 0) return 0;
+  return ((clientX - startX + scrollOffset) / contentWidth) * timelineDuration;
+}
+
+export function getTrimLockedTrackWidth(timelineDuration, pixelsPerSecond) {
+  const duration = Math.max(0, Number(timelineDuration) || 0);
+  const scale = Math.max(0, Number(pixelsPerSecond) || 0);
+  return duration * scale;
+}
+
+export function getTrimTrailingSpacerGeometry(contentWidth, viewportWidth) {
+  return {
+    left: Math.max(0, Number(contentWidth) || 0),
+    width: Math.max(0, Number(viewportWidth) || 0),
+  };
+}
+
+export function getTrimScrollSettleStep(scrollLeft, nativeMaximum, maxStep = 6) {
+  const current = Math.max(0, Number(scrollLeft) || 0);
+  const maximum = Math.max(0, Number(nativeMaximum) || 0);
+  const step = Math.max(0, Number(maxStep) || 0);
+  return Math.max(maximum, current - step);
+}
+
+export function getTimelineEdgeAutoScrollStep(clientX, rect, { threshold = 48, forwardMaxStep = 14, backwardMaxStep = 6 } = {}) {
+  if (!rect || !Number.isFinite(clientX) || rect.width <= 0) return 0;
+  const getStep = (distanceFromEdge, maxStep) => {
+    const strength = Math.min(1, Math.max(0, (threshold - Math.max(0, distanceFromEdge)) / threshold));
+    return Math.max(0.35, strength ** 2 * maxStep);
+  };
+  if (clientX < rect.left + threshold) {
+    return -getStep(clientX - rect.left, backwardMaxStep);
+  }
+  if (clientX > rect.right - threshold) {
+    return getStep(rect.right - clientX, forwardMaxStep);
+  }
+  return 0;
+}
+
+export function createTimelineEdgeAutoScroller({ trackElement, pointerType, timelineDuration = 0, onScrollFrame, win = globalThis.window } = {}) {
+  const scrollElement = trackElement?.parentElement;
+  const isMobile = Boolean(win?.matchMedia?.(MOBILE_TIMELINE_QUERY).matches);
+  const enabled = Boolean(scrollElement) && (
+    (pointerType === "touch" && isMobile)
+    || (["mouse", "pen"].includes(pointerType) && !isMobile)
+  );
+  const rulerElement = enabled ? trackElement.closest?.(".timeline-board")?.querySelector?.(".timeline-ruler-canvas") : null;
+  if (enabled) {
+    trackElement.classList?.add("is-trimming");
+    rulerElement?.classList?.add("is-trimming");
+    const contentWidth = trackElement.getBoundingClientRect?.().width || trackElement.clientWidth || 0;
+    const viewportWidth = scrollElement.clientWidth || contentWidth;
+    if (contentWidth > 0 && timelineDuration > 0 && win?.dispatchEvent && win?.CustomEvent) {
+      flushSync(() => win.dispatchEvent(new win.CustomEvent(TIMELINE_TRIM_SCALE_START_EVENT, {
+        detail: {
+          pixelsPerSecond: contentWidth / timelineDuration,
+          visibleDuration: (viewportWidth * timelineDuration) / contentWidth,
+        },
+      })));
+    }
+  }
+  let previousContentWidth = trackElement?.getBoundingClientRect?.().width || trackElement?.clientWidth || 0;
+  let logicalScrollOffset = 0;
+  let latestClientX = 0;
+  let frameId = 0;
+  let spacerElement = null;
+
+  const updateTrailingSpacer = (contentWidth = previousContentWidth) => {
+    if (!enabled || !spacerElement) return;
+    const geometry = getTrimTrailingSpacerGeometry(contentWidth, scrollElement.clientWidth);
+    spacerElement.style.left = `${geometry.left}px`;
+    spacerElement.style.width = `${geometry.width}px`;
+  };
+
+  if (enabled && scrollElement?.ownerDocument?.createElement) {
+    const previousSpacer = scrollElement.querySelector?.("[data-timeline-trim-scroll-spacer]");
+    previousSpacer?.__timelineTrimCleanup?.();
+    previousSpacer?.remove?.();
+    spacerElement = scrollElement.ownerDocument.createElement("div");
+    spacerElement.setAttribute("data-timeline-trim-scroll-spacer", "");
+    Object.assign(spacerElement.style, {
+      position: "absolute",
+      top: "0",
+      height: "1px",
+      pointerEvents: "none",
+      visibility: "hidden",
+    });
+    updateTrailingSpacer();
+    scrollElement.appendChild(spacerElement);
+  }
+
+  const syncContentWidth = () => {
+    if (!enabled) return;
+    const nextContentWidth = trackElement?.getBoundingClientRect?.().width || trackElement?.clientWidth || previousContentWidth;
+    updateTrailingSpacer(nextContentWidth);
+    previousContentWidth = nextContentWidth;
+  };
+
+  const tick = () => {
+    frameId = 0;
+    if (!enabled) return;
+    syncContentWidth();
+    const rect = scrollElement.getBoundingClientRect();
+    const step = getTimelineEdgeAutoScrollStep(latestClientX, rect);
+    if (!step) return;
+    const before = scrollElement.scrollLeft;
+    const requestedScrollDelta = step < 0 ? Math.max(-before, step) : step;
+    if (requestedScrollDelta) {
+      flushSync(() => onScrollFrame?.(latestClientX, logicalScrollOffset + requestedScrollDelta));
+      syncContentWidth();
+      const maximumAfterUpdate = Math.max(0, scrollElement.scrollWidth - scrollElement.clientWidth);
+      const beforeEdgeScroll = scrollElement.scrollLeft;
+      scrollElement.scrollLeft = Math.max(0, Math.min(maximumAfterUpdate, beforeEdgeScroll + requestedScrollDelta));
+      logicalScrollOffset += scrollElement.scrollLeft - beforeEdgeScroll;
+    }
+    const after = scrollElement.scrollLeft;
+    const maximum = Math.max(0, scrollElement.scrollWidth - scrollElement.clientWidth);
+    if (!frameId && ((step < 0 && after > 0) || (step > 0 && after < maximum))) frameId = win.requestAnimationFrame(tick);
+  };
+
+  return {
+    update(clientX) {
+      latestClientX = clientX;
+      if (enabled && !frameId) frameId = win.requestAnimationFrame(tick);
+    },
+    getScrollOffset() {
+      return enabled ? logicalScrollOffset : 0;
+    },
+    stop() {
+      if (frameId) win.cancelAnimationFrame(frameId);
+      frameId = 0;
+      if (enabled && win?.dispatchEvent && win?.CustomEvent) {
+        flushSync(() => win.dispatchEvent(new win.CustomEvent(TIMELINE_TRIM_SCALE_END_EVENT)));
+      }
+      trackElement?.classList?.remove("is-trimming");
+      rulerElement?.classList?.remove("is-trimming");
+      syncContentWidth();
+      if (spacerElement) {
+        let settleFrameId = 0;
+        const removeSpacer = () => {
+          if (settleFrameId) win.cancelAnimationFrame(settleFrameId);
+          settleFrameId = 0;
+          spacerElement?.remove?.();
+          spacerElement = null;
+        };
+        const settleSpacer = () => {
+          settleFrameId = 0;
+          const nativeMaximum = Math.max(0, previousContentWidth - scrollElement.clientWidth);
+          if (scrollElement.scrollLeft <= nativeMaximum + 0.5) {
+            removeSpacer();
+            return;
+          }
+          scrollElement.scrollLeft = getTrimScrollSettleStep(scrollElement.scrollLeft, nativeMaximum);
+          settleFrameId = win.requestAnimationFrame(settleSpacer);
+        };
+        spacerElement.__timelineTrimCleanup = removeSpacer;
+        settleSpacer();
+      }
+    },
+  };
+}

--- a/src/lib/timelineEdgeAutoScroll.js
+++ b/src/lib/timelineEdgeAutoScroll.js
@@ -29,6 +29,18 @@ export function getTrimScrollSettleStep(scrollLeft, nativeMaximum, maxStep = 6) 
   return Math.max(maximum, current - step);
 }
 
+export function getTimelineTrimDragClientX(clientX, rect, inset = 10) {
+  if (!rect || !Number.isFinite(clientX) || !(rect.width > 0)) return clientX;
+  const safeInset = Math.max(0, Math.min(rect.width / 2, Number(inset) || 0));
+  return Math.max(rect.left + safeInset, Math.min(rect.right - safeInset, clientX));
+}
+
+export function getMobileTrimReleaseScrollLeft(scrollLeft, trackWidth) {
+  const current = Math.max(0, Number(scrollLeft) || 0);
+  const width = Math.max(0, Number(trackWidth) || 0);
+  return width > 0 ? Math.min(current, width) : current;
+}
+
 export function getTimelineEdgeAutoScrollStep(clientX, rect, { threshold = 48, forwardMaxStep = 14, backwardMaxStep = 6 } = {}) {
   if (!rect || !Number.isFinite(clientX) || rect.width <= 0) return 0;
   const getStep = (distanceFromEdge, maxStep) => {
@@ -134,6 +146,11 @@ export function createTimelineEdgeAutoScroller({ trackElement, pointerType, time
     getScrollOffset() {
       return enabled ? logicalScrollOffset : 0;
     },
+    getDragClientX(clientX) {
+      return enabled
+        ? getTimelineTrimDragClientX(clientX, scrollElement.getBoundingClientRect())
+        : clientX;
+    },
     stop() {
       if (frameId) win.cancelAnimationFrame(frameId);
       frameId = 0;
@@ -143,6 +160,9 @@ export function createTimelineEdgeAutoScroller({ trackElement, pointerType, time
       trackElement?.classList?.remove("is-trimming");
       rulerElement?.classList?.remove("is-trimming");
       syncContentWidth();
+      if (isMobile) {
+        scrollElement.scrollLeft = getMobileTrimReleaseScrollLeft(scrollElement.scrollLeft, previousContentWidth);
+      }
       if (spacerElement) {
         let settleFrameId = 0;
         const removeSpacer = () => {

--- a/src/lib/timelineEdgeAutoScroll.js
+++ b/src/lib/timelineEdgeAutoScroll.js
@@ -51,6 +51,7 @@ export function createTimelineEdgeAutoScroller({ trackElement, pointerType, time
     (pointerType === "touch" && isMobile)
     || (["mouse", "pen"].includes(pointerType) && !isMobile)
   );
+  const usesDesktopTrailingSpacer = enabled && !isMobile;
   const rulerElement = enabled ? trackElement.closest?.(".timeline-board")?.querySelector?.(".timeline-ruler-canvas") : null;
   if (enabled) {
     trackElement.classList?.add("is-trimming");
@@ -79,7 +80,7 @@ export function createTimelineEdgeAutoScroller({ trackElement, pointerType, time
     spacerElement.style.width = `${geometry.width}px`;
   };
 
-  if (enabled && scrollElement?.ownerDocument?.createElement) {
+  if (usesDesktopTrailingSpacer && scrollElement?.ownerDocument?.createElement) {
     const previousSpacer = scrollElement.querySelector?.("[data-timeline-trim-scroll-spacer]");
     previousSpacer?.__timelineTrimCleanup?.();
     previousSpacer?.remove?.();

--- a/src/lib/timelineEdgeAutoScroll.test.js
+++ b/src/lib/timelineEdgeAutoScroll.test.js
@@ -66,6 +66,29 @@ describe("mobile timeline edge auto-scroll", () => {
     expect(rulerClasses.has("is-trimming")).toBe(false);
   });
 
+  it("never creates or settles a desktop trailing spacer on mobile", () => {
+    let appended = 0;
+    const scrollElement = {
+      clientWidth: 400,
+      scrollLeft: 120,
+      ownerDocument: { createElement: () => ({}) },
+      appendChild: () => { appended += 1; },
+    };
+    const track = {
+      classList: { add() {}, remove() {} },
+      closest: () => null,
+      parentElement: scrollElement,
+    };
+    const scroller = createTimelineEdgeAutoScroller({
+      trackElement: track,
+      pointerType: "touch",
+      win: { matchMedia: () => ({ matches: true }), requestAnimationFrame: () => 1, cancelAnimationFrame() {} },
+    });
+    scroller.stop();
+    expect(appended).toBe(0);
+    expect(scrollElement.scrollLeft).toBe(120);
+  });
+
   it("enables the same edge-scroll lifecycle for desktop mouse trimming", () => {
     const values = new Set();
     const track = {

--- a/src/lib/timelineEdgeAutoScroll.test.js
+++ b/src/lib/timelineEdgeAutoScroll.test.js
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createTimelineEdgeAutoScroller,
+  getTimelineDragTimeDelta,
+  getTimelineEdgeAutoScrollStep,
+  getTrimScrollSettleStep,
+  getTrimTrailingSpacerGeometry,
+  getTrimLockedTrackWidth,
+} from "./timelineEdgeAutoScroll.js";
+
+describe("mobile timeline edge auto-scroll", () => {
+  const rect = { left: 100, right: 500, width: 400 };
+
+  it("scrolls toward the edge with progressive speed", () => {
+    expect(getTimelineEdgeAutoScrollStep(100, rect)).toBe(-6);
+    expect(getTimelineEdgeAutoScrollStep(500, rect)).toBe(14);
+    expect(getTimelineEdgeAutoScrollStep(476, rect)).toBe(3.5);
+  });
+
+  it("returns toward the start more gently than it extends forward", () => {
+    expect(Math.abs(getTimelineEdgeAutoScrollStep(100, rect))).toBeLessThan(getTimelineEdgeAutoScrollStep(500, rect));
+  });
+
+  it("uses one stable scale for pointer and scroll displacement", () => {
+    expect(getTimelineDragTimeDelta({ clientX: 300, startX: 300, scrollOffset: 14, contentWidth: 1000, timelineDuration: 20 })).toBeCloseTo(0.28);
+  });
+
+  it("grows the track instead of compressing time when trimming extends the project", () => {
+    expect(getTrimLockedTrackWidth(20, 50)).toBe(1000);
+    expect(getTrimLockedTrackWidth(25, 50)).toBe(1250);
+  });
+
+  it("reserves one viewport of invisible trailing scroll space", () => {
+    expect(getTrimTrailingSpacerGeometry(1100, 500)).toEqual({ left: 1100, width: 500 });
+  });
+
+  it("settles retained scroll space at the same gentle return speed", () => {
+    expect(getTrimScrollSettleStep(700, 550)).toBe(694);
+    expect(getTrimScrollSettleStep(553, 550)).toBe(550);
+  });
+
+  it("does not scroll inside the safe center region", () => {
+    expect(getTimelineEdgeAutoScrollStep(300, rect)).toBe(0);
+  });
+
+  it("disables width transitions for the full mobile trim gesture", () => {
+    const trackClasses = new Set();
+    const rulerClasses = new Set();
+    const makeClassList = (values) => ({ add: (value) => values.add(value), remove: (value) => values.delete(value) });
+    const ruler = { classList: makeClassList(rulerClasses) };
+    const track = {
+      classList: makeClassList(trackClasses),
+      closest: () => ({ querySelector: () => ruler }),
+      parentElement: { scrollLeft: 0 },
+    };
+    const scroller = createTimelineEdgeAutoScroller({
+      trackElement: track,
+      pointerType: "touch",
+      win: { matchMedia: () => ({ matches: true }), requestAnimationFrame: () => 1, cancelAnimationFrame() {} },
+    });
+    expect(trackClasses.has("is-trimming")).toBe(true);
+    expect(rulerClasses.has("is-trimming")).toBe(true);
+    scroller.stop();
+    expect(trackClasses.has("is-trimming")).toBe(false);
+    expect(rulerClasses.has("is-trimming")).toBe(false);
+  });
+
+  it("enables the same edge-scroll lifecycle for desktop mouse trimming", () => {
+    const values = new Set();
+    const track = {
+      classList: { add: (value) => values.add(value), remove: (value) => values.delete(value) },
+      closest: () => null,
+      parentElement: { scrollLeft: 0 },
+    };
+    const scroller = createTimelineEdgeAutoScroller({
+      trackElement: track,
+      pointerType: "mouse",
+      win: { matchMedia: () => ({ matches: false }), requestAnimationFrame: () => 1, cancelAnimationFrame() {} },
+    });
+    expect(values.has("is-trimming")).toBe(true);
+    scroller.stop();
+    expect(values.has("is-trimming")).toBe(false);
+  });
+
+  it("does not feed content-shrink anchor compensation back into drag time", () => {
+    let contentWidth = 1250;
+    let frameCallback = null;
+    const scrollElement = {
+      clientWidth: 500,
+      scrollLeft: 700,
+      scrollWidth: 1250,
+      getBoundingClientRect: () => ({ left: 100, right: 500, width: 400 }),
+    };
+    const track = {
+      classList: { add() {}, remove() {} },
+      closest: () => null,
+      getBoundingClientRect: () => ({ width: contentWidth }),
+      parentElement: scrollElement,
+    };
+    const scroller = createTimelineEdgeAutoScroller({
+      trackElement: track,
+      pointerType: "mouse",
+      timelineDuration: 25,
+      win: {
+        matchMedia: () => ({ matches: false }),
+        requestAnimationFrame: (callback) => { frameCallback = callback; return 1; },
+        cancelAnimationFrame() {},
+        dispatchEvent() {},
+        CustomEvent: class {},
+      },
+    });
+    scroller.update(300);
+    contentWidth = 1100;
+    scrollElement.scrollWidth = 1100;
+    scrollElement.scrollLeft = 600; // Browser-native clamp before our frame runs.
+    frameCallback();
+    expect(scrollElement.scrollLeft).toBe(600);
+    expect(scroller.getScrollOffset()).toBe(0);
+    scroller.stop();
+  });
+});

--- a/src/lib/timelineEdgeAutoScroll.test.js
+++ b/src/lib/timelineEdgeAutoScroll.test.js
@@ -4,6 +4,8 @@ import {
   createTimelineEdgeAutoScroller,
   getTimelineDragTimeDelta,
   getTimelineEdgeAutoScrollStep,
+  getTimelineTrimDragClientX,
+  getMobileTrimReleaseScrollLeft,
   getTrimScrollSettleStep,
   getTrimTrailingSpacerGeometry,
   getTrimLockedTrackWidth,
@@ -40,6 +42,17 @@ describe("mobile timeline edge auto-scroll", () => {
     expect(getTrimScrollSettleStep(553, 550)).toBe(550);
   });
 
+  it("keeps desktop and mobile trim handles inside the visible viewport", () => {
+    expect(getTimelineTrimDragClientX(520, rect)).toBe(490);
+    expect(getTimelineTrimDragClientX(80, rect)).toBe(110);
+    expect(getTimelineTrimDragClientX(300, rect)).toBe(300);
+  });
+
+  it("prevents the mobile fixed playhead from ending beyond the project", () => {
+    expect(getMobileTrimReleaseScrollLeft(900, 700)).toBe(700);
+    expect(getMobileTrimReleaseScrollLeft(500, 700)).toBe(500);
+  });
+
   it("does not scroll inside the safe center region", () => {
     expect(getTimelineEdgeAutoScrollStep(300, rect)).toBe(0);
   });
@@ -52,7 +65,7 @@ describe("mobile timeline edge auto-scroll", () => {
     const track = {
       classList: makeClassList(trackClasses),
       closest: () => ({ querySelector: () => ruler }),
-      parentElement: { scrollLeft: 0 },
+      parentElement: { scrollLeft: 0, getBoundingClientRect: () => rect },
     };
     const scroller = createTimelineEdgeAutoScroller({
       trackElement: track,
@@ -89,12 +102,38 @@ describe("mobile timeline edge auto-scroll", () => {
     expect(scrollElement.scrollLeft).toBe(120);
   });
 
+  it("clamps only mobile release scrolling to the final track end", () => {
+    const createScroller = (isMobile, pointerType) => {
+      const scrollElement = {
+        clientWidth: 400,
+        scrollLeft: 900,
+        getBoundingClientRect: () => rect,
+      };
+      const track = {
+        classList: { add() {}, remove() {} },
+        closest: () => null,
+        getBoundingClientRect: () => ({ width: 700 }),
+        parentElement: scrollElement,
+      };
+      const scroller = createTimelineEdgeAutoScroller({
+        trackElement: track,
+        pointerType,
+        win: { matchMedia: () => ({ matches: isMobile }), requestAnimationFrame: () => 1, cancelAnimationFrame() {} },
+      });
+      scroller.stop();
+      return scrollElement.scrollLeft;
+    };
+
+    expect(createScroller(true, "touch")).toBe(700);
+    expect(createScroller(false, "mouse")).toBe(900);
+  });
+
   it("enables the same edge-scroll lifecycle for desktop mouse trimming", () => {
     const values = new Set();
     const track = {
       classList: { add: (value) => values.add(value), remove: (value) => values.delete(value) },
       closest: () => null,
-      parentElement: { scrollLeft: 0 },
+      parentElement: { scrollLeft: 0, getBoundingClientRect: () => rect },
     };
     const scroller = createTimelineEdgeAutoScroller({
       trackElement: track,
@@ -102,6 +141,7 @@ describe("mobile timeline edge auto-scroll", () => {
       win: { matchMedia: () => ({ matches: false }), requestAnimationFrame: () => 1, cancelAnimationFrame() {} },
     });
     expect(values.has("is-trimming")).toBe(true);
+    expect(scroller.getDragClientX(520)).toBe(490);
     scroller.stop();
     expect(values.has("is-trimming")).toBe(false);
   });

--- a/src/lib/timelineMoveControls.js
+++ b/src/lib/timelineMoveControls.js
@@ -173,7 +173,8 @@ export function createTimelineMoveControls(d) {
       if (!moved) d.pauseForTimelineEdit?.();
       moved = true; e.preventDefault();
       autoScroller?.update(e.clientX);
-      const delta = getTimelineDragTimeDelta({ clientX: e.clientX, startX, scrollOffset, contentWidth: rect.width, timelineDuration });
+      const dragClientX = autoScroller?.getDragClientX(e.clientX) ?? e.clientX;
+      const delta = getTimelineDragTimeDelta({ clientX: dragClientX, startX, scrollOffset, contentWidth: rect.width, timelineDuration });
       let nextStart = edge === "start"
         ? Math.max(0, Math.min(originalEnd - MIN_VISUAL_SEGMENT_SECONDS, originalStart + delta))
         : originalStart;

--- a/src/lib/timelineMoveControls.js
+++ b/src/lib/timelineMoveControls.js
@@ -1,5 +1,6 @@
 import { DEFAULT_STICKER_SEGMENT_SECONDS, MAX_TIMELINE_DURATION_SECONDS, MIN_VISUAL_SEGMENT_SECONDS } from "../config/editor.js";
 import { collectTimelineSnapPoints, findClosestTimelineSnap, snapTimelineRange } from "./timelineSnap.js";
+import { createTimelineEdgeAutoScroller, getTimelineDragTimeDelta } from "./timelineEdgeAutoScroll.js";
 
 export function createTimelineMoveControls(d) {
   const startSingleTrackMove = (event, track) => {
@@ -145,27 +146,34 @@ export function createTimelineMoveControls(d) {
     if (event.button !== 0) return;
     const segment = d.stickerSegments.find((item) => item.id === id); if (!segment) return;
     if (d.trackLocks.sticker) return void d.notify("贴纸轨已锁定，无法调整片段时长");
-    const rect = d.trackScrollRef.current?.getBoundingClientRect();
-    const timelineDuration = d.timelineDurationRef.current || Math.max(d.estimatedDuration, segment.start + segment.duration, 10);
-    if (!rect || timelineDuration <= 0) return;
     const isMobileTouch = event.pointerType === "touch" && globalThis.window?.matchMedia?.("(max-width: 760px)").matches;
     if (!isMobileTouch) event.preventDefault();
     event.stopPropagation();
     d.setSelectedTrack("sticker"); d.setActiveTool("stickers"); d.setSelectedStickerSegmentId(segment.id);
     if (segment.stickerId) d.setSelectedStickerId(segment.stickerId);
     const startX = event.clientX; const startY = event.clientY;
+    const timelineDuration = d.timelineDurationRef.current || Math.max(d.estimatedDuration, segment.start + segment.duration, 10);
+    const autoScroller = createTimelineEdgeAutoScroller({
+      trackElement: d.trackScrollRef.current,
+      pointerType: event.pointerType,
+      timelineDuration,
+      onScrollFrame: (clientX, scrollOffset) => move({ clientX, clientY: startY, preventDefault() {} }, scrollOffset),
+    });
+    const rect = d.trackScrollRef.current?.getBoundingClientRect();
+    if (!rect || timelineDuration <= 0) { autoScroller.stop(); return; }
     const originalStart = segment.start || 0; const originalDuration = Math.max(MIN_VISUAL_SEGMENT_SECONDS, segment.duration || DEFAULT_STICKER_SEGMENT_SECONDS);
     const originalEnd = originalStart + originalDuration;
     const snapPoints = collectTimelineSnapPoints(d, { track: "sticker", id: segment.id });
     let moved = false; let latestStart = originalStart; let latestDuration = originalDuration;
     const applyRange = (start, duration) => d.setStickerSegments((items) => items.map((item) => item.id === segment.id ? { ...item, start, duration } : item));
-    const move = (e) => {
+    const move = (e, scrollOffset = autoScroller?.getScrollOffset() || 0) => {
       const deltaX = e.clientX - startX; const deltaY = e.clientY - startY;
       if (!moved && isMobileTouch && Math.abs(deltaY) > Math.abs(deltaX)) return;
       if (!moved && Math.abs(deltaX) < 3) return;
       if (!moved) d.pauseForTimelineEdit?.();
       moved = true; e.preventDefault();
-      const delta = (deltaX / Math.max(rect.width, 1)) * timelineDuration;
+      autoScroller?.update(e.clientX);
+      const delta = getTimelineDragTimeDelta({ clientX: e.clientX, startX, scrollOffset, contentWidth: rect.width, timelineDuration });
       let nextStart = edge === "start"
         ? Math.max(0, Math.min(originalEnd - MIN_VISUAL_SEGMENT_SECONDS, originalStart + delta))
         : originalStart;
@@ -183,7 +191,7 @@ export function createTimelineMoveControls(d) {
       d.setSnapGuide?.(snap ? { time: snap.time, label: `${snap.time.toFixed(2)}s` } : null);
       d.setTimelineHorizon((value) => Math.max(value, Math.ceil((nextEnd + 5) / 10) * 10));
     };
-    const cleanup = () => { removeEventListener("pointermove", move); removeEventListener("pointerup", up); removeEventListener("pointercancel", cancel); d.setSnapGuide?.(null); };
+    const cleanup = () => { autoScroller.stop(); removeEventListener("pointermove", move); removeEventListener("pointerup", up); removeEventListener("pointercancel", cancel); d.setSnapGuide?.(null); };
     const cancel = () => { cleanup(); if (moved) applyRange(originalStart, originalDuration); };
     const up = () => {
       cleanup(); if (!moved) return;

--- a/src/lib/timelineReorderControls.js
+++ b/src/lib/timelineReorderControls.js
@@ -1,6 +1,7 @@
 import { getVisualSegmentTimeline, materializeCaptionTimings, moveTimedCaptionSegment, reorderTimelineItems } from "./timeline.js";
 import { collectTimelineSnapPoints, findClosestTimelineSnap, snapTimelineRange } from "./timelineSnap.js";
 import { createVisualOverlaySegment } from "./visualOverlayTimeline.js";
+import { createTimelineEdgeAutoScroller, getTimelineDragTimeDelta } from "./timelineEdgeAutoScroll.js";
 
 export function createTimelineReorderControls(d) {
   const getTimelineReorderIndex = (track, x, y) => {
@@ -125,8 +126,14 @@ export function createTimelineReorderControls(d) {
     if (!caption || caption.id !== segmentId) return;
     d.setSelectedTrack("caption"); d.setSelectedSegmentId(segmentId);
     const trackElement = document.querySelector('[data-timeline-reorder-track="caption"]');
-    const trackWidth = Math.max(1, trackElement?.getBoundingClientRect().width || 1);
     const startX = event.clientX;
+    const autoScroller = createTimelineEdgeAutoScroller({
+      trackElement: d.trackScrollRef?.current,
+      pointerType: event.pointerType,
+      timelineDuration: d.timelineDuration,
+      onScrollFrame: (clientX, scrollOffset) => move({ clientX, preventDefault() {} }, scrollOffset),
+    });
+    const trackWidth = Math.max(1, trackElement?.getBoundingClientRect().width || 1);
     const snapPoints = collectTimelineSnapPoints(d, { track: "caption", id: segmentId });
     const initial = {
       track: "caption", mode: edge === "start" ? "resize-start" : "resize-end", segmentId,
@@ -134,12 +141,13 @@ export function createTimelineReorderControls(d) {
       previewStart: caption.start, previewEnd: caption.end, previewSegments: materialized, dragging: false,
     };
     d.timelineClipDragRef.current = initial; d.setTimelineClipDrag(initial);
-    const move = (moveEvent) => {
+    const move = (moveEvent, scrollOffset = autoScroller?.getScrollOffset() || 0) => {
       const state = d.timelineClipDragRef.current;
       if (!state || state.segmentId !== segmentId) return;
       if (!state.dragging && Math.abs(moveEvent.clientX - startX) < 3) return;
       if (!state.dragging) d.pauseForTimelineEdit?.();
-      const delta = ((moveEvent.clientX - startX) / trackWidth) * d.timelineDuration;
+      autoScroller?.update(moveEvent.clientX);
+      const delta = getTimelineDragTimeDelta({ clientX: moveEvent.clientX, startX, scrollOffset, contentWidth: trackWidth, timelineDuration: d.timelineDuration });
       const minimumDuration = 0.2;
       let previewStart = edge === "start"
         ? Math.max(0, Math.min(state.originalEnd - minimumDuration, state.originalStart + delta))
@@ -158,15 +166,22 @@ export function createTimelineReorderControls(d) {
       d.timelineClipDragRef.current = next; d.setTimelineClipDrag(next);
       d.setSnapGuide?.(snap ? { time: snap.time, label: `${snap.time.toFixed(2)}s` } : null);
     };
+    const cleanup = () => {
+      autoScroller.stop();
+      removeEventListener("pointermove", move); removeEventListener("pointerup", up); removeEventListener("pointercancel", cancel);
+    };
+    const cancel = () => {
+      cleanup(); d.timelineClipDragRef.current = null; d.setTimelineClipDrag(null); d.setSnapGuide?.(null);
+    };
     const up = () => {
-      removeEventListener("pointermove", move); removeEventListener("pointerup", up);
+      cleanup();
       const state = d.timelineClipDragRef.current; d.timelineClipDragRef.current = null; d.setTimelineClipDrag(null); d.setSnapGuide?.(null);
       if (!state?.dragging) return;
       d.suppressTimelineClipClickRef.current = segmentId;
       setTimeout(() => { if (d.suppressTimelineClipClickRef.current === segmentId) d.suppressTimelineClipClickRef.current = ""; }, 120);
       d.commitCaptionSegments(state.previewSegments, "已调整字幕片段时长", index);
     };
-    addEventListener("pointermove", move); addEventListener("pointerup", up, { once: true });
+    addEventListener("pointermove", move); addEventListener("pointerup", up, { once: true }); addEventListener("pointercancel", cancel, { once: true });
   };
   return { commitTimelineClipReorder, getTimelineReorderIndex, startCaptionResize, startTimelineClipDrag };
 }

--- a/src/lib/timelineReorderControls.js
+++ b/src/lib/timelineReorderControls.js
@@ -147,7 +147,8 @@ export function createTimelineReorderControls(d) {
       if (!state.dragging && Math.abs(moveEvent.clientX - startX) < 3) return;
       if (!state.dragging) d.pauseForTimelineEdit?.();
       autoScroller?.update(moveEvent.clientX);
-      const delta = getTimelineDragTimeDelta({ clientX: moveEvent.clientX, startX, scrollOffset, contentWidth: trackWidth, timelineDuration: d.timelineDuration });
+      const dragClientX = autoScroller?.getDragClientX(moveEvent.clientX) ?? moveEvent.clientX;
+      const delta = getTimelineDragTimeDelta({ clientX: dragClientX, startX, scrollOffset, contentWidth: trackWidth, timelineDuration: d.timelineDuration });
       const minimumDuration = 0.2;
       let previewStart = edge === "start"
         ? Math.max(0, Math.min(state.originalEnd - minimumDuration, state.originalStart + delta))

--- a/src/lib/timelineScale.js
+++ b/src/lib/timelineScale.js
@@ -46,6 +46,12 @@ export function getTimelineZoomForVisibleDuration(visibleDuration) {
   return clampTimelineZoom((low + high) / 2);
 }
 
+export function getTimelineVisibleDurationForPixelScale(pixelsPerSecond, scaleBasisWidth) {
+  const scale = Math.max(0, Number(pixelsPerSecond) || 0);
+  const basis = Math.max(0, Number(scaleBasisWidth) || 0);
+  return scale > 0 ? basis / scale : 0;
+}
+
 export function getTimelineAutoFitZoom(contentDuration, fillRatio = 0.82) {
   const safeDuration = Math.max(0.5, Number(contentDuration) || 0.5);
   const safeFillRatio = Math.max(0.5, Math.min(0.9, Number(fillRatio) || 0.82));

--- a/src/lib/timelineScale.test.js
+++ b/src/lib/timelineScale.test.js
@@ -21,6 +21,21 @@ describe("timeline ruler density", () => {
 
     expect(ticks.filter((tick) => tick.isMajor).some((tick) => tick.label === "00:00.50")).toBe(true);
   });
+
+  it("keeps labeled ticks in view while trimming expands a long mobile project", () => {
+    const visibleDuration = 10;
+    const ticks = getTimelineRulerTicks(
+      100,
+      getTimelineZoomForVisibleDuration(visibleDuration),
+      41,
+      51,
+      { minimumMajorStep: (visibleDuration * 88) / 520 },
+    );
+    const visibleLabels = ticks.filter((tick) => tick.isMajor && tick.time >= 41 && tick.time <= 51);
+
+    expect(visibleLabels.length).toBeGreaterThanOrEqual(4);
+    expect(visibleLabels.every((tick) => tick.label)).toBe(true);
+  });
 });
 
 describe("mobile timeline pinch zoom", () => {

--- a/src/lib/timelineScale.test.js
+++ b/src/lib/timelineScale.test.js
@@ -5,10 +5,17 @@ import {
   getMobilePinchZoomState,
   getTimelineRulerTicks,
   getTimelineTrackWidthPercent,
+  getTimelineVisibleDurationForPixelScale,
   getTimelineZoomForVisibleDuration,
 } from "./timelineScale.js";
 
 describe("timeline ruler density", () => {
+  it("keeps mobile trim release on the canonical track-width scale", () => {
+    const pixelsPerSecond = 65;
+    expect(getTimelineVisibleDurationForPixelScale(pixelsPerSecond, 520)).toBe(8);
+    expect(getTimelineVisibleDurationForPixelScale(pixelsPerSecond, 260)).toBe(4);
+  });
+
   it("raises mobile major tick spacing so short-timeline labels do not overlap", () => {
     const ticks = getTimelineRulerTicks(4, 3, 0, 4, { minimumMajorStep: 0.68 });
     const labels = ticks.filter((tick) => tick.isMajor).map((tick) => tick.label);

--- a/src/styles.css
+++ b/src/styles.css
@@ -3146,7 +3146,7 @@ button:disabled {
 .visual-overlay-clip.is-selected-segment { border-color: #58a6ff; box-shadow: 0 0 0 2px rgba(88,166,255,.28), 0 0 14px rgba(88,166,255,.25); filter: brightness(1.12); }
 .clip-mute-toggle { position: absolute; top: 4px; left: 4px; z-index: 5; display: grid; place-items: center; width: 22px; height: 22px; border: 1px solid rgba(255,255,255,.18); border-radius: 5px; padding: 0; color: #eef8fb; background: rgba(5,10,14,.78); cursor: pointer; }
 .clip-mute-toggle:hover { color: #071616; background: #35ead9; }
-.visual-overlay-resize { position: absolute; top: 4px; bottom: 4px; width: 6px; border-radius: 3px; background: rgba(232,244,255,.9); opacity: 0; cursor: ew-resize; }
+.visual-overlay-resize { position: absolute; top: 4px; bottom: 4px; width: 6px; border-radius: 3px; background: rgba(232,244,255,.9); opacity: 0; cursor: ew-resize; touch-action: none; }
 .visual-overlay-resize.is-start { left: 2px; }
 .visual-overlay-resize.is-end { right: 2px; }
 .visual-overlay-clip.is-selected-segment .visual-overlay-resize { opacity: 1; }
@@ -4398,6 +4398,11 @@ button:disabled {
   transition: none;
 }
 
+.track-scroll.is-trimming,
+.timeline-ruler-canvas.is-trimming {
+  transition: none;
+}
+
 .ruler {
   position: relative;
   display: block;
@@ -5001,6 +5006,7 @@ button:disabled {
   cursor: ew-resize;
   opacity: 0;
   transition: opacity 120ms ease, background 120ms ease;
+  touch-action: none;
 }
 
 .caption-resize-handle.is-start { left: 0; }
@@ -5134,6 +5140,7 @@ button:disabled {
   cursor: ew-resize;
   opacity: 0;
   transition: opacity 120ms ease, background 120ms ease;
+  touch-action: none;
 }
 
 .sticker-resize-handle.is-start { left: 0; }
@@ -6134,6 +6141,18 @@ button:disabled {
   .caption-segment,
   .sticker-segment,
   .audio-clip { touch-action: pan-y; }
+  .image-clip,
+  .image-clip img,
+  .image-clip video,
+  .visual-overlay-clip,
+  .visual-overlay-clip img,
+  .visual-overlay-clip video,
+  .sticker-segment,
+  .sticker-segment img {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
+  }
   @keyframes mobile-clip-actions-enter {
     from { opacity: 0; transform: translateY(12px); }
     to { opacity: 1; transform: translateY(0); }
@@ -6186,6 +6205,7 @@ button:disabled {
   .media-panel > .library-provider { flex: 0 0 auto; }
   .media-panel > .asset-list,
   .media-panel > .tool-panel,
+  .media-panel > .mobile-panel-scroll-body,
   .voice-panel > .voice-tab-body {
     flex: 1 1 0;
     height: 0;
@@ -6193,6 +6213,22 @@ button:disabled {
     overflow-x: hidden;
     overflow-y: auto;
     overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
+  }
+  .media-panel > .audio-tool-panel.mobile-panel-scroll-body {
+    box-sizing: border-box;
+    flex: 1 1 0;
+    width: 100%;
+    height: 0;
+    min-height: 0;
+    max-height: none;
+    padding: 0 8px max(28px, env(safe-area-inset-bottom)) 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior-y: contain;
+    scrollbar-gutter: auto;
+    scroll-padding-bottom: max(28px, env(safe-area-inset-bottom));
     -webkit-overflow-scrolling: touch;
     touch-action: pan-y;
   }


### PR DESCRIPTION
## What changed

- add CapCut-style edge auto-scroll for timeline trim handles on desktop and mobile
- preserve stable timeline scale and ruler labels during trimming
- keep return scrolling gentle and clean up temporary trailing scroll space after release
- keep the first-visual guide on desktop while suppressing it on mobile
- include the current mobile audio-panel scrolling and local server host updates

## Root cause

Timeline resizing mixed pointer displacement, native scroll clamping, and auto-scroll displacement. This caused jumps, drift, and inconsistent return speed when the project duration changed during a gesture.

## Validation

- targeted Vitest suite: 27 tests passed
- TypeScript check passed
- production Vite build passed