### PR TITLE
Fix auto-edit multimodal prompt failures

### DIFF
--- a/src/hooks/useAutoEdit.js
+++ b/src/hooks/useAutoEdit.js
@@ -115,7 +115,7 @@ export function useAutoEdit({ language, visualSegments, captionSegments, commitC
       session = await sessionPromise;
       translator = await translatorPromise;
       const captions = await generateFrameCaptions({
-        frames, duration: getVisualSegmentsTotal(visualSegments), language, session, translator,
+        frames, duration: getVisualSegmentsTotal(visualSegments), language, session, translator, signal: abortRef.current.signal,
         onPartial: (partial) => {
           const modelProgress = partial.allWindows ? partial.completedWindows / partial.allWindows : 0;
           setJob({ running: true, progress: Math.min(96, 60 + Math.round(modelProgress * 36)), phase: t("autoEditWritingCaptions") });

--- a/src/lib/autoEdit.js
+++ b/src/lib/autoEdit.js
@@ -338,23 +338,49 @@ export async function generateImageVoiceoverText({ src, language = "en", signal 
   }
 }
 
-async function generateCaptionGroup(session, frames, duration, modelLanguage, translator) {
+async function withIsolatedPromptSession(session, signal, callback) {
+  const isolated = typeof session.clone === "function" ? await session.clone({ signal }) : session;
+  try {
+    return await callback(isolated);
+  } finally {
+    if (isolated !== session) isolated.destroy?.();
+  }
+}
+
+async function generateSingleFrameCaption(session, frame, outputLanguage, schema, signal) {
+  return withIsolatedPromptSession(session, signal, async (promptSession) => {
+    const response = await promptSession.prompt([{ role: "user", content: [
+      { type: "text", value: `Write one concise on-screen caption in ${outputLanguage} describing only what is visibly happening in this video frame at ${frame.time.toFixed(2)} seconds. Return a meaningful non-empty caption. Do not mention the timestamp.` },
+      { type: "image", value: frame.blob },
+    ] }], { responseConstraint: schema, signal });
+    return String(JSON.parse(response)?.text || "").trim();
+  });
+}
+
+async function generateCaptionGroup(session, frames, duration, modelLanguage, translator, signal) {
   const outputLanguage = getAutoEditLanguageName(modelLanguage);
   const content = [{ type: "text", value: `Describe every provided candidate frame with one concise on-screen caption. Output only in ${outputLanguage}. Return exactly ${frames.length} captions in the same order as the images. Use only visible evidence; do not invent names or facts. Frame timestamps: ${frames.map((frame) => frame.time.toFixed(2)).join(", ")} seconds.` }];
   frames.forEach((frame) => content.push({ type: "image", value: frame.blob }));
   const schema = { type: "object", properties: { captions: { type: "array", minItems: frames.length, maxItems: frames.length, items: { type: "object", properties: { text: { type: "string", minLength: 1 } }, required: ["text"], additionalProperties: false } } }, required: ["captions"], additionalProperties: false };
-  const response = await session.prompt([{ role: "user", content }], { responseConstraint: schema });
-  const returned = JSON.parse(response)?.captions;
-  const descriptions = Array.isArray(returned) ? returned.map((item) => String(item?.text || "").trim()) : [];
   const singleSchema = { type: "object", properties: { text: { type: "string", minLength: 1 } }, required: ["text"], additionalProperties: false };
+  let descriptions;
+  try {
+    const response = await withIsolatedPromptSession(session, signal, (promptSession) =>
+      promptSession.prompt([{ role: "user", content }], { responseConstraint: schema, signal })
+    );
+    const returned = JSON.parse(response)?.captions;
+    descriptions = Array.isArray(returned) ? returned.map((item) => String(item?.text || "").trim()) : [];
+  } catch (error) {
+    if (error?.name === "AbortError") throw error;
+    // Chrome's local multimodal model can reject a valid multi-image request
+    // with kErrorUnknown on some GPU/model combinations. Retry each image in
+    // an isolated session so one oversized/unstable batch does not fail a clip.
+    descriptions = [];
+  }
   for (let index = 0; index < frames.length; index += 1) {
     if (descriptions[index]) continue;
     const frame = frames[index];
-    const singleResponse = await session.prompt([{ role: "user", content: [
-      { type: "text", value: `Write one concise on-screen caption in ${outputLanguage} describing only what is visibly happening in this video frame at ${frame.time.toFixed(2)} seconds. Return a meaningful non-empty caption. Do not mention the timestamp.` },
-      { type: "image", value: frame.blob },
-    ] }], { responseConstraint: singleSchema });
-    descriptions[index] = String(JSON.parse(singleResponse)?.text || "").trim();
+    descriptions[index] = await generateSingleFrameCaption(session, frame, outputLanguage, singleSchema, signal);
   }
   const translatedDescriptions = await Promise.all(descriptions.map((text) => translateText(text, translator)));
   return frames.map((frame, index) => ({
@@ -377,7 +403,7 @@ function createSlidingWindows(frames, size = 6, overlap = 2) {
   return windows;
 }
 
-export async function generateFrameCaptions({ frames, duration, language, session: providedSession, translator: providedTranslator, onDownloadProgress, onPartial }) {
+export async function generateFrameCaptions({ frames, duration, language, session: providedSession, translator: providedTranslator, onDownloadProgress, onPartial, signal }) {
   const modelLanguage = getAutoEditPromptLanguage(language);
   const session = providedSession || await createFrameCaptionSession({ language, onDownloadProgress });
   const translator = providedTranslator === undefined ? await createAutoEditTranslator({ language, onDownloadProgress }) : providedTranslator;
@@ -401,7 +427,7 @@ export async function generateFrameCaptions({ frames, duration, language, sessio
       try {
         for (let windowIndex = 0; windowIndex < windows.length; windowIndex += 1) {
           const window = windows[windowIndex];
-          const generated = await generateCaptionGroup(session, window.frames, duration, modelLanguage, translator);
+          const generated = await generateCaptionGroup(session, window.frames, duration, modelLanguage, translator, signal);
           // Overlap gives the model context; each window commits only its new time region.
           const committed = generated.filter((caption) => (caption.start + caption.end) / 2 < window.commitEnd || windowIndex === windows.length - 1);
           groupCaptions.push(...committed);

--- a/src/lib/autoEdit.test.js
+++ b/src/lib/autoEdit.test.js
@@ -114,6 +114,45 @@ describe("auto edit", () => {
     expect(onPartial.mock.calls.map(([value]) => value.status)).toEqual(["running", "running", "complete"]);
     expect(onPartial.mock.calls[1][0]).toMatchObject({ windowIndex: 1, totalWindows: 1 });
   });
+  it("retries frames individually when Chrome rejects a multi-image prompt", async () => {
+    const unknown = new DOMException("An unknown error occurred: kErrorUnknown", "OperationError");
+    const session = {
+      prompt: vi.fn()
+        .mockRejectedValueOnce(unknown)
+        .mockResolvedValueOnce('{"text":"The editor timeline is empty"}')
+        .mockResolvedValueOnce('{"text":"A video appears in the preview"}'),
+    };
+    const result = await generateFrameCaptions({
+      frames: [
+        { segmentId: "clip-a", segmentStart: 0, segmentEnd: 4, time: 0, blob: {} },
+        { segmentId: "clip-a", segmentStart: 0, segmentEnd: 4, time: 2, blob: {} },
+      ],
+      duration: 4,
+      language: "en",
+      session,
+    });
+    expect(result.map(({ text }) => text)).toEqual(["The editor timeline is empty", "A video appears in the preview"]);
+    expect(session.prompt).toHaveBeenCalledTimes(3);
+  });
+  it("isolates each model window from prior image context when cloning is supported", async () => {
+    const clones = [];
+    const session = {
+      clone: vi.fn(async () => {
+        const clone = {
+          prompt: vi.fn().mockResolvedValue('{"captions":[{"text":"A"},{"text":"B"},{"text":"C"},{"text":"D"},{"text":"E"},{"text":"F"}]}'),
+          destroy: vi.fn(),
+        };
+        clones.push(clone);
+        return clone;
+      }),
+    };
+    const frames = Array.from({ length: 9 }, (_, index) => ({
+      segmentId: "clip-a", segmentStart: 0, segmentEnd: 18, time: index * 2, blob: {},
+    }));
+    await generateFrameCaptions({ frames, duration: 18, language: "en", session });
+    expect(session.clone).toHaveBeenCalledTimes(2);
+    expect(clones.every((clone) => clone.destroy.mock.calls.length === 1)).toBe(true);
+  });
   it("returns one model result for every candidate frame", async () => {
     const session = { prompt: vi.fn().mockResolvedValue('{"captions":[{"text":"A"},{"text":"B"},{"text":"C"},{"text":"D"}]}') };
     const frames = Array.from({ length: 4 }, (_, index) => ({ segmentId: "clip-a", segmentStart: 0, segmentEnd: 8, time: index * 2, blob: {} }));


### PR DESCRIPTION
## What changed

- isolate each auto-edit caption window in a cloned Chrome Prompt API session
- fall back to per-frame caption generation when a multi-image request fails
- propagate the active abort signal through model prompts
- add regression coverage for `kErrorUnknown` fallback and nine-frame session isolation

## Why

Chrome's local multimodal model can reject an otherwise valid multi-image prompt with `kErrorUnknown` on some model/GPU combinations. The previous implementation treated that batch failure as a failure for the entire visual clip. Reusing one conversational session across windows also accumulated prior image context.

The new fallback preserves the fast batch path while recovering with isolated single-frame requests, and cloned sessions prevent image history from leaking across windows.

## Impact

Auto Edit can continue generating captions when Chrome rejects a multi-image batch instead of leaving the clip in a failed state. Cancellation now also reaches active prompt calls.

## Validation

- `npm test -- --run src/lib/autoEdit.test.js` — 16 tests passed
- `npm run lint -- --quiet`
- `npm run build`
- manually imported and inspected the reported 1880×1080, 36.6s H.264/AAC video in the local editor
- user confirmed the fix works in a Chrome environment with the built-in model enabled
