### PR TITLE
Fix person cutout playback after background removal

### DIFF
--- a/src/components/PreviewStage.jsx
+++ b/src/components/PreviewStage.jsx
@@ -553,8 +553,18 @@ export function PreviewStage({
                 />
               </div>
             ) : null}
-            {renderedVisualSrc && trackVisibility.image && !replacesBackground ? (
-              <div className={`visual-media-layer ${visualTransformEditable ? "is-transform-editable" : ""}`} style={visualMaskStyle} onPointerDown={(event) => { event.stopPropagation(); onSelectVisual?.(); if (visualTransformEditable) startVisualTransform(event, "move"); }}>
+            {renderedVisualSrc && trackVisibility.image ? (
+              <div
+                className={`visual-media-layer ${visualTransformEditable ? "is-transform-editable" : ""} ${replacesBackground ? "is-subject-sync-source" : ""}`}
+                style={visualMaskStyle}
+                aria-hidden={replacesBackground ? "true" : undefined}
+                onPointerDown={(event) => {
+                  if (replacesBackground) return;
+                  event.stopPropagation();
+                  onSelectVisual?.();
+                  if (visualTransformEditable) startVisualTransform(event, "move");
+                }}
+              >
                 {previewVisualType === "image" ? <img
                   src={renderedVisualSrc}
                   alt={t("currentMediaAlt")}

--- a/src/styles.css
+++ b/src/styles.css
@@ -4241,6 +4241,11 @@ button:disabled {
   overflow: hidden;
 }
 
+.visual-media-layer.is-subject-sync-source {
+  opacity: 0;
+  pointer-events: none;
+}
+
 
 .visual-media-layer.is-transform-editable { cursor: move; }
 


### PR DESCRIPTION
## What changed

- keep the source video mounted as an invisible synchronization layer when Person outline removes or replaces the original background
- prevent the synchronization layer from intercepting preview-canvas pointer interactions

## Why

Removing the video background previously unmounted the primary video element. The temporal person analysis used that element's media time to select the active Alpha frame, so playback remained stuck on the cutout image captured when the material was applied.

## Impact

Person outline clips now continue switching through their analyzed cutout frames during timeline playback with the video background disabled. Export behavior is unchanged because export already resolves the temporal Alpha independently for every rendered frame.

## Validation

- manually confirmed the affected workflow now plays through the processed video
- `npm run check`
  - ESLint completed with existing warnings and no errors
  - TypeScript completed without errors
  - Vite production build completed successfully
- `git diff --check`
