### PR TITLE
Improve model cache reliability and project badges

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -4,6 +4,7 @@
 
 [![skills.sh](https://skills.sh/b/MartinDelophy/ai-video-editor)](https://skills.sh/MartinDelophy/ai-video-editor)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
+<a href="https://www.producthunt.com/products/timeline-studio-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-timeline-studio-2" target="_blank" rel="noopener noreferrer"><img alt="Timeline Studio - Local-first AI video editing in your browser | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196911&amp;theme=light&amp;t=1785378187636"></a>
 
 ## Projektneuigkeiten
 

--- a/README.es.md
+++ b/README.es.md
@@ -4,6 +4,7 @@
 
 [![skills.sh](https://skills.sh/b/MartinDelophy/ai-video-editor)](https://skills.sh/MartinDelophy/ai-video-editor)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
+<a href="https://www.producthunt.com/products/timeline-studio-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-timeline-studio-2" target="_blank" rel="noopener noreferrer"><img alt="Timeline Studio - Local-first AI video editing in your browser | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196911&amp;theme=light&amp;t=1785378187636"></a>
 
 ## Novedades del proyecto
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -4,6 +4,7 @@
 
 [![skills.sh](https://skills.sh/b/MartinDelophy/ai-video-editor)](https://skills.sh/MartinDelophy/ai-video-editor)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
+<a href="https://www.producthunt.com/products/timeline-studio-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-timeline-studio-2" target="_blank" rel="noopener noreferrer"><img alt="Timeline Studio - Local-first AI video editing in your browser | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196911&amp;theme=light&amp;t=1785378187636"></a>
 
 ## Actualités du projet
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,6 +4,7 @@
 
 [![skills.sh](https://skills.sh/b/MartinDelophy/ai-video-editor)](https://skills.sh/MartinDelophy/ai-video-editor)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
+<a href="https://www.producthunt.com/products/timeline-studio-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-timeline-studio-2" target="_blank" rel="noopener noreferrer"><img alt="Timeline Studio - Local-first AI video editing in your browser | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196911&amp;theme=light&amp;t=1785378187636"></a>
 
 ## プロジェクト更新
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -4,6 +4,7 @@
 
 [![skills.sh](https://skills.sh/b/MartinDelophy/ai-video-editor)](https://skills.sh/MartinDelophy/ai-video-editor)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
+<a href="https://www.producthunt.com/products/timeline-studio-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-timeline-studio-2" target="_blank" rel="noopener noreferrer"><img alt="Timeline Studio - Local-first AI video editing in your browser | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196911&amp;theme=light&amp;t=1785378187636"></a>
 
 ## 프로젝트 업데이트
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![MIT License](https://img.shields.io/github/license/MartinDelophy/ai-video-editor?style=flat-square)](LICENSE)
 [![skills.sh](https://skills.sh/b/MartinDelophy/ai-video-editor)](https://skills.sh/MartinDelophy/ai-video-editor)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
+<a href="https://www.producthunt.com/products/timeline-studio-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-timeline-studio-2" target="_blank" rel="noopener noreferrer"><img alt="Timeline Studio - Local-first AI video editing in your browser | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196911&amp;theme=light&amp;t=1785378187636"></a>
 <a href="https://toolindex.net/tools/timeline-studio?ref=badge" target="_blank" rel="noopener">
   <img src="https://toolindex.net/badge/timeline-studio/small.svg?theme=dark" alt="Timeline Studio - Listed on Tool Index" width="130" height="30" />
 </a>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -4,6 +4,7 @@
 
 [![skills.sh](https://skills.sh/b/MartinDelophy/ai-video-editor)](https://skills.sh/MartinDelophy/ai-video-editor)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
+<a href="https://www.producthunt.com/products/timeline-studio-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-timeline-studio-2" target="_blank" rel="noopener noreferrer"><img alt="Timeline Studio - Local-first AI video editing in your browser | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196911&amp;theme=light&amp;t=1785378187636"></a>
 
 ## Novidades do projeto
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -4,6 +4,7 @@
 
 [![skills.sh](https://skills.sh/b/MartinDelophy/ai-video-editor)](https://skills.sh/MartinDelophy/ai-video-editor)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
+<a href="https://www.producthunt.com/products/timeline-studio-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-timeline-studio-2" target="_blank" rel="noopener noreferrer"><img alt="Timeline Studio - Local-first AI video editing in your browser | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196911&amp;theme=light&amp;t=1785378187636"></a>
 
 ## Новости проекта
 

--- a/README.th.md
+++ b/README.th.md
@@ -4,6 +4,7 @@
 
 [![skills.sh](https://skills.sh/b/MartinDelophy/ai-video-editor)](https://skills.sh/MartinDelophy/ai-video-editor)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
+<a href="https://www.producthunt.com/products/timeline-studio-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-timeline-studio-2" target="_blank" rel="noopener noreferrer"><img alt="Timeline Studio - Local-first AI video editing in your browser | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196911&amp;theme=light&amp;t=1785378187636"></a>
 
 ## ข่าวสารโครงการ
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -4,6 +4,7 @@
 
 [![skills.sh](https://skills.sh/b/MartinDelophy/ai-video-editor)](https://skills.sh/MartinDelophy/ai-video-editor)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
+<a href="https://www.producthunt.com/products/timeline-studio-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-timeline-studio-2" target="_blank" rel="noopener noreferrer"><img alt="Timeline Studio - Local-first AI video editing in your browser | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196911&amp;theme=light&amp;t=1785378187636"></a>
 
 ## Cập nhật dự án
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,6 +7,7 @@
 [![MIT License](https://img.shields.io/github/license/MartinDelophy/ai-video-editor?style=flat-square)](LICENSE)
 [![skills.sh](https://skills.sh/b/MartinDelophy/ai-video-editor)](https://skills.sh/MartinDelophy/ai-video-editor)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
+<a href="https://www.producthunt.com/products/timeline-studio-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-timeline-studio-2" target="_blank" rel="noopener noreferrer"><img alt="Timeline Studio - Local-first AI video editing in your browser | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196911&amp;theme=light&amp;t=1785378187636"></a>
 
 ## 项目动态
 

--- a/huggingface-space/README.md
+++ b/huggingface-space/README.md
@@ -21,6 +21,7 @@ license: mit
 
 # Timeline Studio
 
+<a href="https://www.producthunt.com/products/timeline-studio-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-timeline-studio-2" target="_blank" rel="noopener noreferrer"><img alt="Timeline Studio - Local-first AI video editing in your browser | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196911&amp;theme=light&amp;t=1785378187636"></a>
 <a href="https://trendshift.io/repositories/77422?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-77422" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/77422/daily?language=JavaScript" alt="MartinDelophy%2Fai-video-editor | Trendshift" width="250" height="55"/></a>
 <a href="https://trendshift.io/repositories/77422?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-77422" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/77422/weekly?language=JavaScript" alt="MartinDelophy%2Fai-video-editor | Trendshift" width="250" height="55"/></a>
 

--- a/public/model-cache-sw.js
+++ b/public/model-cache-sw.js
@@ -127,14 +127,25 @@ function withCacheStatus(response, status) {
 async function cacheFirst(request, event) {
   const cache = await caches.open(MODEL_CACHE_NAME);
   const cacheRequest = canonicalModelCacheRequest(request);
-  let cached = await cache.match(cacheRequest) || await cache.match(request);
+  let cached = await cache.match(cacheRequest);
+  let needsCanonicalMigration = false;
+  if (!cached && cacheRequest.url !== request.url) {
+    cached = await cache.match(request);
+    needsCanonicalMigration = Boolean(cached);
+  }
   if (!cached && cacheRequest.url !== request.url) {
     const keys = await cache.keys();
     const equivalent = keys.find((key) => canonicalModelCacheRequest(key).url === cacheRequest.url);
-    if (equivalent) cached = await cache.match(equivalent);
+    if (equivalent) {
+      cached = await cache.match(equivalent);
+      needsCanonicalMigration = Boolean(cached && equivalent.url !== cacheRequest.url);
+    }
   }
   if (cached) {
-    if (cacheRequest.url !== request.url) {
+    // Only copy legacy source-specific entries into the canonical key. A
+    // canonical hit must never overwrite itself while its body is streaming
+    // to the requesting worker; doing so can leave reader.read() pending.
+    if (needsCanonicalMigration) {
       event.waitUntil(cache.put(cacheRequest, cached.clone()).catch(() => {}));
     }
     return withCacheStatus(cached, "hit");

--- a/skills/edit-timeline-studio/README.md
+++ b/skills/edit-timeline-studio/README.md
@@ -1,5 +1,6 @@
 # AI Video Editing Skill for Codex, Claude Code, Copilot and Gemini CLI
 
+<a href="https://www.producthunt.com/products/timeline-studio-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-timeline-studio-2" target="_blank" rel="noopener noreferrer"><img alt="Timeline Studio - Local-first AI video editing in your browser | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196911&amp;theme=light&amp;t=1785378187636"></a>
 <a href="https://trendshift.io/repositories/77422?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-77422" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/77422/daily?language=JavaScript" alt="MartinDelophy%2Fai-video-editor | Trendshift" width="250" height="55"/></a>
 <a href="https://trendshift.io/repositories/77422?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-77422" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/77422/weekly?language=JavaScript" alt="MartinDelophy%2Fai-video-editor | Trendshift" width="250" height="55"/></a>
 

--- a/src/workers/miganRepair.worker.js
+++ b/src/workers/miganRepair.worker.js
@@ -8,6 +8,8 @@ const MODEL_CACHE_KEY =
 const MODEL_BYTES = 24_743_604;
 const MODEL_SIZE = 256;
 const CACHE_NAME = "timeline-studio-migan-generator-256-webgpu-v1";
+const SHARED_MODEL_CACHE_NAME = "timeline-studio-model-cache-v4";
+const MODEL_READ_STALL_TIMEOUT_MS = 20_000;
 
 ort.env.wasm.numThreads = 1;
 ort.env.wasm.wasmPaths = "/vendor/migan-ort/";
@@ -18,10 +20,17 @@ function report(requestId, stage, value, extra = {}) {
   self.postMessage({ type: "progress", requestId, stage, value, ...extra });
 }
 
+function validateModelSize(byteLength) {
+  if (byteLength !== MODEL_BYTES) {
+    throw new Error(`MODEL_SIZE_MISMATCH:${byteLength}:${MODEL_BYTES}`);
+  }
+}
+
 async function readResponse(response, requestId, source) {
   const total = Number(response.headers.get("content-length")) || MODEL_BYTES;
   if (!response.body) {
     const bytes = await response.arrayBuffer();
+    validateModelSize(bytes.byteLength);
     report(requestId, "download", 1, { loaded: bytes.byteLength, total, source });
     return bytes;
   }
@@ -29,12 +38,28 @@ async function readResponse(response, requestId, source) {
   const chunks = [];
   let loaded = 0;
   while (true) {
-    const { done, value } = await reader.read();
+    let timer = 0;
+    let chunk;
+    try {
+      chunk = await Promise.race([
+        reader.read(),
+        new Promise((_, reject) => {
+          timer = setTimeout(() => reject(new Error("MODEL_READ_STALLED")), MODEL_READ_STALL_TIMEOUT_MS);
+        }),
+      ]);
+    } catch (error) {
+      await reader.cancel().catch(() => {});
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+    const { done, value } = chunk;
     if (done) break;
     chunks.push(value);
     loaded += value.byteLength;
     report(requestId, "download", Math.min(1, loaded / total), { loaded, total, source });
   }
+  validateModelSize(loaded);
   const merged = new Uint8Array(loaded);
   let offset = 0;
   chunks.forEach((chunk) => { merged.set(chunk, offset); offset += chunk.byteLength; });
@@ -44,19 +69,41 @@ async function readResponse(response, requestId, source) {
 async function createSession(requestId, modelSourcePreference) {
   const cache = await caches.open(CACHE_NAME);
   const cached = await cache.match(MODEL_CACHE_KEY);
-  let model;
-  if (cached) model = await readResponse(cached, requestId, "cache");
-  else {
-    const { response } = await fetchFirstAvailableModel(mirroredModelFileUrls({
-      repository: "timeline-studio-onnx-models",
-      revision: MODEL_REVISION,
-      path: MODEL_PATH,
-      preference: modelSourcePreference,
-    }));
-    model = await readResponse(response, requestId, "network");
-    await cache.put(MODEL_CACHE_KEY, new Response(model, {
+  let model = null;
+  if (cached) {
+    try {
+      model = await readResponse(cached, requestId, "cache");
+    } catch {
+      await cache.delete(MODEL_CACHE_KEY).catch(() => false);
+    }
+  }
+  if (!model) {
+    let retriedSharedCache = false;
+    while (!model) {
+      const { response } = await fetchFirstAvailableModel(mirroredModelFileUrls({
+        repository: "timeline-studio-onnx-models",
+        revision: MODEL_REVISION,
+        path: MODEL_PATH,
+        preference: modelSourcePreference,
+      }));
+      try {
+        model = await readResponse(response, requestId, "network");
+      } catch (error) {
+        const fromSharedCache = response.headers.get("X-Timeline-Model-Cache") === "hit";
+        if (!retriedSharedCache && fromSharedCache) {
+          retriedSharedCache = true;
+          const sharedCache = await caches.open(SHARED_MODEL_CACHE_NAME);
+          await sharedCache.delete(MODEL_CACHE_KEY).catch(() => false);
+          continue;
+        }
+        throw error;
+      }
+    }
+    // Model initialization should not wait on persistent storage. Cache writes
+    // can be slow or quota-limited even when the downloaded model is valid.
+    cache.put(MODEL_CACHE_KEY, new Response(model, {
       headers: { "Content-Type": "application/octet-stream", "Content-Length": String(model.byteLength) },
-    }));
+    })).catch(() => {});
   }
   report(requestId, "compile", 0);
   const started = performance.now();


### PR DESCRIPTION
## What changed

- Add the Product Hunt featured badge across the primary, localized, Hugging Face Space, and Timeline Studio skill documentation.
- Prevent canonical model-cache hits from overwriting their own actively streamed response.
- Validate MI-GAN model byte length, detect stalled cache/network reads, evict corrupt cache entries, retry shared-cache failures once, and avoid blocking inference startup on persistent cache writes.

## Why

The remaining workspace changes improve project discovery and make browser-local model downloads resilient to corrupt, incomplete, or stalled cached responses. They were intentionally kept separate from the Object outline feature PR so both changesets remain reviewable.

## Validation

- `npm run check`
- Production Vite build
- `git diff --check`
