### PR TITLE
Show generated face swap frames on the timeline

### DIFF
--- a/src/hooks/useFaceSwapGeneration.js
+++ b/src/hooks/useFaceSwapGeneration.js
@@ -9,6 +9,7 @@ import {
   createGeneratedMediaMetadata,
   embedGeneratedMediaMetadata,
 } from "../lib/generatedMediaMetadata.js";
+import { createVideoTrackFramesFromBlobs } from "../lib/media.js";
 
 function createWorker() {
   return new Worker(new URL("../workers/face-swap.worker.js", import.meta.url), { type: "module" });
@@ -149,7 +150,18 @@ export function useFaceSwapGeneration(d) {
       }
       const contentId = crypto.randomUUID();
       const generationMetadata = createGeneratedMediaMetadata({ contentId });
-      blob = await embedGeneratedMediaMetadata(blob, generationMetadata);
+      const [embeddedBlob, trackFrames] = await Promise.all([
+        embedGeneratedMediaMetadata(blob, generationMetadata),
+        result.type === "video-frames"
+          ? createVideoTrackFramesFromBlobs(result.blobs, {
+              duration: result.duration,
+              width: result.width,
+              height: result.height,
+              signal: controller.signal,
+            })
+          : [],
+      ]);
+      blob = embeddedBlob;
       const url = URL.createObjectURL(blob);
       d.imageUrlRefs.current.add(url);
       const extension = result.type === "image" ? "png" : "webm";
@@ -164,7 +176,8 @@ export function useFaceSwapGeneration(d) {
         duration: result.duration,
         width: result.width,
         height: result.height,
-        trackFrames: [],
+        trackFrames,
+        trackFrameDuration: result.type === "video-frames" ? result.duration : 0,
         generatedBy: "mobilefaceswap-224",
         generationMetadata,
         diagnostics: {
@@ -174,6 +187,7 @@ export function useFaceSwapGeneration(d) {
           inferenceMs: result.inferenceMs || 0,
           model: result.model || "mobilefaceswap-224",
           totalFrames: result.totalFrames || 1,
+          timelineFrames: trackFrames.length,
         },
       };
       console.info("[Face Swap][Performance]", JSON.stringify(asset.diagnostics));

--- a/src/lib/media.js
+++ b/src/lib/media.js
@@ -165,6 +165,51 @@ export async function extractVideoTrackFrames(src, options = {}) {
   }
 }
 
+export async function createVideoTrackFramesFromBlobs(blobs, options = {}) {
+  const sourceFrames = Array.isArray(blobs) ? blobs.filter((blob) => blob instanceof Blob) : [];
+  if (!sourceFrames.length) return [];
+  const {
+    duration,
+    width,
+    height,
+    maxFrames = VIDEO_TRACK_FRAME_MAX,
+    quality = 0.72,
+    signal,
+  } = options;
+  const frameCount = Math.min(
+    sourceFrames.length,
+    getVideoTrackSampleCount(Math.max(0, Number(duration) || 0), maxFrames),
+  );
+  if (!frameCount) return [];
+  const naturalWidth = Math.max(1, Number(width) || 16);
+  const naturalHeight = Math.max(1, Number(height) || 9);
+  const canvas = document.createElement("canvas");
+  canvas.height = VIDEO_TRACK_FRAME_HEIGHT;
+  canvas.width = Math.max(36, Math.min(180, Math.round(canvas.height * naturalWidth / naturalHeight)));
+  const context = canvas.getContext("2d", { alpha: false });
+  if (!context) return [];
+
+  const frames = [];
+  for (let index = 0; index < frameCount; index += 1) {
+    if (signal?.aborted) throw signal.reason || new DOMException("Aborted", "AbortError");
+    const sourceIndex = Math.max(
+      0,
+      Math.min(
+        sourceFrames.length - 1,
+        Math.round(((index + 0.5) / frameCount) * sourceFrames.length - 0.5),
+      ),
+    );
+    const bitmap = await createImageBitmap(sourceFrames[sourceIndex]);
+    try {
+      context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+      frames.push(canvas.toDataURL("image/jpeg", quality));
+    } finally {
+      bitmap.close();
+    }
+  }
+  return frames;
+}
+
 export async function decodeWaveform(blob, barCount = 118) {
   const AudioContextClass = window.AudioContext || window.webkitAudioContext;
   if (!AudioContextClass) {


### PR DESCRIPTION
## What changed

- Build compact timeline thumbnails directly from the WebP frames already produced by face-swap generation.
- Store the sampled frames and matching `trackFrameDuration` on the generated video asset.
- Reuse the same real frame sequence when the asset is placed on the main Visuals track or any Overlay lane.
- Record the sampled-frame count in face-swap performance diagnostics.

## Why

Generated face-swap videos previously had an empty `trackFrames` array. The timeline therefore rendered one large video surface across the whole clip instead of the frame-by-frame strip used by ordinary imported videos.

## How it was tested

- [x] `npm run check` passes with 0 errors
- [x] `npm run typecheck` passes
- [x] Local editor reloads without runtime errors
- [x] Main Visuals and Overlay segment creation preserve `trackFrames` and `trackFrameDuration`

Expected 2-second result: approximately 10 compact timeline thumbnails instead of one stretched block.